### PR TITLE
Add render_corpus_helpers and render_pneuma_helpers MCP tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ Model Context Protocol (MCP) server providing platform context and tools to AI a
 | `get_team` | `{team_key: string}` | `{spec: <object>}` (same shape `validate_team_spec` accepts) |
 | `lookup_user` | `{github_username: string} \| {email: string}` | `{matches: [{team_key, via, system, scope, subject, membership}]}` |
 | `find_repo` | `{name: string}` | `{matches: [{team_key, repository: <object>}]}` |
+| `render_corpus_helpers` | `{team_key: string}` | `{helpers_tofu: string}` (canonical `pt-corpus/helpers.tofu` bytes with `<team_key>-main-production` inserted) |
+| `render_pneuma_helpers` | `{team_key: string}` | `{helpers_tofu: string}` (same, for `pt-pneuma/helpers.tofu`) |
 
 `render_team_tfvars` validates first; on failure it returns an MCP `isError` result with the same structured errors as `validate_team_spec`.
 
@@ -26,22 +28,24 @@ Model Context Protocol (MCP) server providing platform context and tools to AI a
 - `find_repo` matches GitHub repository names case-sensitively. Empty `matches` is success, not an error.
 - `get_team` returns `not_found` for an unknown `team_key`.
 
+`render_corpus_helpers` and `render_pneuma_helpers` fetch `helpers.tofu` from `osinfra-io/pt-corpus@main` and `osinfra-io/pt-pneuma@main` respectively, insert `<team_key>-main-production` into the `logos_workspaces` list inside the `module "core_helpers"` block, and return the canonical updated file bytes. They are **idempotent**: when the workspace is already present, the input bytes are returned byte-identical. They preserve every other byte of the file (comments, indentation, line-ending style, trailing-comma convention) and refuse to rewrite a file whose `logos_workspaces` is anything other than a list of plain string literals (returns `source_parse_error`). These tools produce bytes only — they do not open PRs; the caller (or a follow-up tool) is responsible for landing the change.
+
 ## Configuration
 
 ### `GITHUB_TOKEN`
 
-Required by `open_team_pr` and the four read tools (`list_teams`, `get_team`, `lookup_user`, `find_repo`). Without it the server still serves `validate_team_spec` and `render_team_tfvars`; the GitHub-backed tools return a structured `not_configured` error.
+Required by `open_team_pr`, the four pt-logos read tools (`list_teams`, `get_team`, `lookup_user`, `find_repo`), and the two helpers renderers (`render_corpus_helpers`, `render_pneuma_helpers`). Without it the server still serves `validate_team_spec` and `render_team_tfvars`; the GitHub-backed tools return a structured `not_configured` error.
 
-The token must be scoped to `osinfra-io/pt-logos` with two write permissions:
+The token must be scoped to **`osinfra-io/pt-logos`**, **`osinfra-io/pt-corpus`**, and **`osinfra-io/pt-pneuma`** with the following permissions:
 
-- **Contents — read and write** (read commits, create branches, write blobs/trees, push commits).
-- **Pull requests — read and write** (list, open, and update PRs).
+- On `pt-logos`: **Contents — read and write**, **Pull requests — read and write** (used by `open_team_pr` plus the four read tools).
+- On `pt-corpus` and `pt-pneuma`: **Contents — read** (used by `render_corpus_helpers` and `render_pneuma_helpers` to fetch `helpers.tofu`).
 
 How to express that depends on the token source:
 
-- **GitHub App** (recommended for non-interactive deployments). In the App's settings, repository permissions → Contents: Read and write, Pull requests: Read and write; repository access → Only select repositories → `osinfra-io/pt-logos`. Mint installation tokens with [`actions/create-github-app-token`](https://github.com/actions/create-github-app-token) (already used elsewhere in the org) and pass the result as `GITHUB_TOKEN`.
-- **Fine-grained PAT** (local development). At <https://github.com/settings/personal-access-tokens>, resource owner `osinfra-io`; repository access → Only select repositories → `osinfra-io/pt-logos`; repository permissions → Contents: Read and write, Pull requests: Read and write.
-- **`gh auth token`** works for local development as long as your account can push to a branch on `pt-logos` and open PRs against it. Prefer a fine-grained PAT or App token for anything non-interactive.
+- **GitHub App** (recommended for non-interactive deployments). In the App's settings, repository permissions → Contents: Read and write, Pull requests: Read and write; repository access → Only select repositories → `osinfra-io/pt-logos`, `osinfra-io/pt-corpus`, `osinfra-io/pt-pneuma`. (Read-only on corpus/pneuma is enough — the App-permissions UI does not let you set per-repo permission levels, so the same Read/Write set applies to all selected repos; if least privilege matters, use a separate App for the helpers renderers.) Mint installation tokens with [`actions/create-github-app-token`](https://github.com/actions/create-github-app-token) (already used elsewhere in the org) and pass the result as `GITHUB_TOKEN`.
+- **Fine-grained PAT** (local development). At <https://github.com/settings/personal-access-tokens>, resource owner `osinfra-io`; repository access → Only select repositories → `osinfra-io/pt-logos`, `osinfra-io/pt-corpus`, `osinfra-io/pt-pneuma`; repository permissions → Contents: Read and write, Pull requests: Read and write. (Same per-repo permission caveat as the App option above.)
+- **`gh auth token`** works for local development as long as your account can push to a branch on `pt-logos` and open PRs against it, and read `pt-corpus` and `pt-pneuma`. Prefer a fine-grained PAT or App token for anything non-interactive.
 - **Classic PAT** is not recommended — the closest equivalent (`repo` scope) grants far more than the tool needs.
 
 ### Operational errors
@@ -56,8 +60,8 @@ How to express that depends on the token source:
   |---|---|---|
   | `not_configured` | false | `GITHUB_TOKEN` was empty at startup. Set it and restart. |
   | `not_found` | false | `get_team` was called with an unknown `team_key`. |
-  | `invalid_input` | false | `lookup_user` was called with neither or both of `github_username` and `email`. |
-  | `source_parse_error` | false | A `teams/*.tfvars` in `pt-logos@main` failed to parse or validate against the schema. The source must be fixed; retrying will not help. |
+  | `invalid_input` | false | `lookup_user` was called with neither or both of `github_username` and `email`; or `render_corpus_helpers`/`render_pneuma_helpers` was called with a `team_key` that does not match the team-spec regex. |
+  | `source_parse_error` | false | A `teams/*.tfvars` in `pt-logos@main`, or `helpers.tofu` in `pt-corpus@main`/`pt-pneuma@main`, failed to parse, validate, or matched an unsupported shape (e.g. missing `module "core_helpers"` block, `logos_workspaces` not a list of plain strings). The source must be fixed; retrying will not help. |
   | `branch_diverged` | false | The team branch has diverged from `main` and an open PR exists; the tool refuses to rewrite history under a human's PR. Rebase or close the PR, then retry. (write tools only) |
   | `github_conflict` | true | A 409/422 from GitHub raced our write and didn't auto-reconcile. Retry. (write tools only) |
   | `github_api_error` | true | Other GitHub API failure (network, 5xx, unexpected 4xx). Retry; if persistent, check the GitHub status page and the token's permissions. |

--- a/cmd/pt-techne-mcp-server/main.go
+++ b/cmd/pt-techne-mcp-server/main.go
@@ -2,14 +2,17 @@
 // typed tools that platform agents call instead of writing HCL by hand.
 //
 // Tools:
-//   - validate_team_spec  — validate a team spec against schema/team.schema.json
-//   - render_team_tfvars  — render a validated spec to canonical pt-logos tfvars
-//   - open_team_pr        — open or update a PR on osinfra-io/pt-logos with the
+//   - validate_team_spec      — validate a team spec against schema/team.schema.json
+//   - render_team_tfvars      — render a validated spec to canonical pt-logos tfvars
+//   - open_team_pr            — open or update a PR on osinfra-io/pt-logos with the
 //     rendered tfvars (requires GITHUB_TOKEN)
-//   - list_teams          — summary index of every team in pt-logos@main (requires GITHUB_TOKEN)
-//   - get_team            — parsed spec for one team (requires GITHUB_TOKEN)
-//   - lookup_user         — every team and role a user appears in (requires GITHUB_TOKEN)
-//   - find_repo           — which team owns a github repository (requires GITHUB_TOKEN)
+//   - list_teams              — summary index of every team in pt-logos@main (requires GITHUB_TOKEN)
+//   - get_team                — parsed spec for one team (requires GITHUB_TOKEN)
+//   - lookup_user             — every team and role a user appears in (requires GITHUB_TOKEN)
+//   - find_repo               — which team owns a github repository (requires GITHUB_TOKEN)
+//   - render_corpus_helpers   — insert a team's main-production workspace into
+//     osinfra-io/pt-corpus/helpers.tofu (requires GITHUB_TOKEN)
+//   - render_pneuma_helpers   — same for osinfra-io/pt-pneuma/helpers.tofu (requires GITHUB_TOKEN)
 //
 // Transport is stdio only.
 package main
@@ -55,6 +58,8 @@ func main() {
 	tools.GetTeam(server, v, ghClient)
 	tools.LookupUser(server, v, ghClient)
 	tools.FindRepo(server, v, ghClient)
+	tools.RenderCorpusHelpers(server, ghClient)
+	tools.RenderPneumaHelpers(server, ghClient)
 
 	if err := server.Run(ctx, &mcp.StdioTransport{}); err != nil {
 		log.Fatalf("server: %v", err)

--- a/docs/README.md
+++ b/docs/README.md
@@ -9,6 +9,8 @@ code.
 cmd/pt-techne-mcp-server/   — main; wires SDK, registers tools, serves stdio
 internal/spec/              — typed Team struct + JSON Schema validator
 internal/render/            — canonical HCL emitter (pt-logos tfvars)
+internal/helpersrender/     — surgical inserter for logos_workspaces in
+                              pt-corpus / pt-pneuma helpers.tofu
 internal/github/            — narrow Client interface + go-github wrapper
 internal/tools/             — thin MCP adapters around spec + render + github
 internal/schemadoc/         — generator for docs/schema.md
@@ -42,9 +44,11 @@ Hard rules:
                            │ uses
             ┌──────────────────────────────┐         ┌──────────────────────────┐
             │ internal/tools.{Validate,    │ ──────► │ internal/render.Render   │
-            │   Render, OpenTeamPR,        │         └──────────────────────────┘
-            │   ListTeams, GetTeam,        │
-            │   LookupUser, FindRepo}      │
+            │   Render, OpenTeamPR,        │         │ internal/helpersrender   │
+            │   ListTeams, GetTeam,        │         └──────────────────────────┘
+            │   LookupUser, FindRepo,      │
+            │   RenderCorpusHelpers,       │
+            │   RenderPneumaHelpers}       │
             └──────────┬───────────────────┘
                        │ all GitHub-backed tools
                        ▼
@@ -61,7 +65,7 @@ diverge; `make sync-schema` updates the copy.
 
 ## Read tools vs write tools
 
-`open_team_pr` is the only **writer**. The four readers — `list_teams`,
+`open_team_pr` is the only **writer**. The four pt-logos readers — `list_teams`,
 `get_team`, `lookup_user`, `find_repo` — share a common shape implemented
 in `internal/tools/team_source.go`:
 
@@ -70,6 +74,18 @@ in `internal/tools/team_source.go`:
    `SetLimit(8)`) of `GetFile` + `spec.Parse` + schema validate per team.
 3. Tool-specific transformation of the parsed `[]*spec.Team` into the
    typed output.
+
+The two helpers renderers — `render_corpus_helpers` and
+`render_pneuma_helpers` — are also reads, but against sibling repos
+(`pt-corpus`, `pt-pneuma`) rather than `pt-logos`. They use
+`Client.GetFileInRepo` (the only cross-repo method on the GitHub
+client; the rest of the surface is pt-logos-only) to fetch each repo's
+`helpers.tofu`, then call `internal/helpersrender.Render` to splice in
+one new line for the team's `<team_key>-main-production` workspace and
+return the canonical updated bytes. No writes — the agent is
+responsible for landing the output (typically by checking the bytes
+into a PR with the same tooling it already uses for `helpers.tofu`
+edits).
 
 `spec.Parse` (the inverse of `render.Render`) uses
 `hashicorp/hcl/v2/hclsyntax` to evaluate the `teams` attribute to a cty
@@ -128,6 +144,27 @@ sorted key order so output is deterministic.
 Field order inside a team body is enumerated explicitly by `emitTeamBody`.
 That function is the contract: if you add a new top-level team field, add it
 there in the right alphabetical position.
+
+`internal/helpersrender/render.go` is a different shape of renderer with a
+different contract: instead of producing a whole file from a typed spec,
+it surgically edits an existing `helpers.tofu` from a sibling repo and
+inserts one new entry into the `logos_workspaces` list. The contract:
+
+- **Byte-identical noop.** If the workspace is already present, the input
+  bytes are returned unchanged.
+- **Minimal diff.** Only the bytes for the new line are added; existing
+  entries, comments, indentation, line-ending style (LF/CRLF), and
+  trailing-comma convention are preserved exactly.
+- **Strict input shape.** Exactly one `module "core_helpers"` block with
+  exactly one `logos_workspaces` attribute; the attribute must be a list
+  literal of plain string literals. Anything else is rejected with
+  `source_parse_error` rather than guessed at.
+
+The implementation parses with `hashicorp/hcl/v2/hclsyntax` to locate
+the list and read its existing string values, then byte-splices a new
+line into the source at the correct position. `hclwrite` was considered
+and rejected: its token-level rewriting normalizes formatting in ways
+that fight the byte-identical-noop contract.
 
 ## Tests
 

--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -6,6 +6,7 @@ package github
 import (
 	"context"
 	"errors"
+	"fmt"
 	"net/http"
 	"sort"
 
@@ -148,11 +149,11 @@ func (c *goClient) GetFileInRepo(ctx context.Context, repo, path, ref string) ([
 		if resp != nil && resp.StatusCode == http.StatusNotFound {
 			return nil, "", false, nil
 		}
-		return nil, "", false, err
+		return nil, "", false, fmt.Errorf("get %s/%s@%s: %w", repo, path, ref, err)
 	}
 	body, err := file.GetContent()
 	if err != nil {
-		return nil, "", false, err
+		return nil, "", false, fmt.Errorf("decode %s/%s@%s: %w", repo, path, ref, err)
 	}
 	return []byte(body), file.GetSHA(), true, nil
 }

--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -49,6 +49,12 @@ type Client interface {
 	CompareCommits(ctx context.Context, base, head string) (CompareStatus, error)
 	GetFile(ctx context.Context, path, ref string) (content []byte, blobSHA string, exists bool, err error)
 	ListDir(ctx context.Context, path, ref string) (names []string, exists bool, err error)
+	// GetFileInRepo reads a single file from a sibling repo under
+	// osinfra-io. Used by the helpers renderers (render_corpus_helpers,
+	// render_pneuma_helpers) which fetch helpers.tofu from pt-corpus and
+	// pt-pneuma respectively. Read-only; the write methods above remain
+	// pt-logos-only.
+	GetFileInRepo(ctx context.Context, repo, path, ref string) (content []byte, blobSHA string, exists bool, err error)
 	CreateOrUpdateFile(ctx context.Context, path, branch, blobSHA string, content []byte, message string) (commitSHA string, err error)
 	ListOpenPRs(ctx context.Context, head, base string) ([]PullRequest, error)
 	CreatePR(ctx context.Context, head, base, title, body string) (PullRequest, error)
@@ -123,6 +129,21 @@ func (c *goClient) CompareCommits(ctx context.Context, base, head string) (Compa
 
 func (c *goClient) GetFile(ctx context.Context, path, ref string) ([]byte, string, bool, error) {
 	file, _, resp, err := c.api.Repositories.GetContents(ctx, Owner, Repo, path, &gh.RepositoryContentGetOptions{Ref: ref})
+	if err != nil {
+		if resp != nil && resp.StatusCode == http.StatusNotFound {
+			return nil, "", false, nil
+		}
+		return nil, "", false, err
+	}
+	body, err := file.GetContent()
+	if err != nil {
+		return nil, "", false, err
+	}
+	return []byte(body), file.GetSHA(), true, nil
+}
+
+func (c *goClient) GetFileInRepo(ctx context.Context, repo, path, ref string) ([]byte, string, bool, error) {
+	file, _, resp, err := c.api.Repositories.GetContents(ctx, Owner, repo, path, &gh.RepositoryContentGetOptions{Ref: ref})
 	if err != nil {
 		if resp != nil && resp.StatusCode == http.StatusNotFound {
 			return nil, "", false, nil

--- a/internal/helpersrender/render.go
+++ b/internal/helpersrender/render.go
@@ -76,6 +76,10 @@ func Render(existing []byte, workspace string) ([]byte, error) {
 		return nil, fmt.Errorf("logos_workspaces is empty; cannot infer style for insertion")
 	}
 
+	if !elementsOnOwnLines(existing, tup) {
+		return nil, fmt.Errorf("logos_workspaces must use one element per line")
+	}
+
 	eol := detectEOL(existing)
 	indent := elementIndent(existing, tup.Exprs[0].Range())
 	insertIdx := alphaInsertIndex(values, workspace)
@@ -160,6 +164,27 @@ func detectEOL(src []byte) string {
 		return "\r\n"
 	}
 	return "\n"
+}
+
+// elementsOnOwnLines reports whether each element of tup starts on its
+// own line (preceded only by whitespace). The byte-splice strategy in
+// insertBefore / appendAfterLast assumes one-element-per-line
+// formatting; rejecting inline forms like `["a", "b"]` here keeps the
+// renderer from producing malformed output.
+func elementsOnOwnLines(src []byte, tup *hclsyntax.TupleConsExpr) bool {
+	for _, expr := range tup.Exprs {
+		r := expr.Range()
+		if r.Start.Byte <= 0 || r.Start.Byte > len(src) {
+			return false
+		}
+		lineStart := bytes.LastIndexByte(src[:r.Start.Byte], '\n') + 1
+		for i := lineStart; i < r.Start.Byte; i++ {
+			if src[i] != ' ' && src[i] != '\t' && src[i] != '\r' {
+				return false
+			}
+		}
+	}
+	return true
 }
 
 // elementIndent returns the leading whitespace on the line that

--- a/internal/helpersrender/render.go
+++ b/internal/helpersrender/render.go
@@ -1,0 +1,250 @@
+// Package helpersrender inserts a workspace string into the
+// logos_workspaces list inside a sibling repo's helpers.tofu without
+// reformatting any other byte of the file.
+//
+// The renderer is byte-stable on noop: if the requested workspace is
+// already present, the input bytes are returned unchanged. On insert,
+// only the bytes for the new line are added; existing entries, comments,
+// indentation, line-ending style, and trailing-comma style are
+// preserved exactly.
+//
+// Used by render_corpus_helpers and render_pneuma_helpers, which fetch
+// helpers.tofu from osinfra-io/pt-corpus@main and osinfra-io/pt-pneuma@main
+// respectively.
+package helpersrender
+
+import (
+	"bytes"
+	"fmt"
+	"sort"
+
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hclsyntax"
+)
+
+// Render inserts workspace into the logos_workspaces list inside the
+// module "core_helpers" block of helpers.tofu. The file must contain
+// exactly one such module block and exactly one logos_workspaces
+// attribute. The attribute must be a list literal of bare string
+// literals; computed expressions, mixed types, and other shapes are
+// rejected.
+//
+// If workspace is already present, the returned slice is byte-identical
+// to existing. Otherwise one new line is inserted in alphabetical
+// position relative to the existing entries (or appended at the end if
+// the existing entries are not already sorted), matching the file's
+// indentation, line-ending style, and trailing-comma convention.
+func Render(existing []byte, workspace string) ([]byte, error) {
+	if workspace == "" {
+		return nil, fmt.Errorf("workspace is empty")
+	}
+	f, diags := hclsyntax.ParseConfig(existing, "helpers.tofu", hcl.Pos{Line: 1, Column: 1})
+	if diags.HasErrors() {
+		return nil, fmt.Errorf("parse hcl: %s", diags.Error())
+	}
+	body, ok := f.Body.(*hclsyntax.Body)
+	if !ok {
+		return nil, fmt.Errorf("unexpected body type %T", f.Body)
+	}
+
+	mod, err := findCoreHelpersModule(body)
+	if err != nil {
+		return nil, err
+	}
+	attr, err := findLogosWorkspacesAttr(mod)
+	if err != nil {
+		return nil, err
+	}
+	tup, ok := attr.Expr.(*hclsyntax.TupleConsExpr)
+	if !ok {
+		return nil, fmt.Errorf(`logos_workspaces must be a list literal, got %T`, attr.Expr)
+	}
+
+	values, err := stringElements(tup)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, v := range values {
+		if v == workspace {
+			// Idempotent noop: byte-identical return.
+			return existing, nil
+		}
+	}
+
+	if len(tup.Exprs) == 0 {
+		return nil, fmt.Errorf("logos_workspaces is empty; cannot infer style for insertion")
+	}
+
+	eol := detectEOL(existing)
+	indent := elementIndent(existing, tup.Exprs[0].Range())
+	insertIdx := alphaInsertIndex(values, workspace)
+
+	if insertIdx < len(tup.Exprs) {
+		return insertBefore(existing, tup.Exprs[insertIdx].Range(), workspace, indent, eol), nil
+	}
+	return appendAfterLast(existing, tup, workspace, indent, eol)
+}
+
+// findCoreHelpersModule returns the body of the single
+// module "core_helpers" block in body, erroring if there are zero or
+// more than one.
+func findCoreHelpersModule(body *hclsyntax.Body) (*hclsyntax.Body, error) {
+	var found *hclsyntax.Block
+	for _, b := range body.Blocks {
+		if b.Type != "module" || len(b.Labels) != 1 || b.Labels[0] != "core_helpers" {
+			continue
+		}
+		if found != nil {
+			return nil, fmt.Errorf(`multiple module "core_helpers" blocks found`)
+		}
+		found = b
+	}
+	if found == nil {
+		return nil, fmt.Errorf(`module "core_helpers" block not found`)
+	}
+	return found.Body, nil
+}
+
+// findLogosWorkspacesAttr returns the single logos_workspaces attribute
+// inside mod. The HCL parser already rejects duplicate attributes at
+// parse time so we only need the missing case here.
+func findLogosWorkspacesAttr(mod *hclsyntax.Body) (*hclsyntax.Attribute, error) {
+	attr, ok := mod.Attributes["logos_workspaces"]
+	if !ok {
+		return nil, fmt.Errorf(`logos_workspaces attribute not found in module "core_helpers"`)
+	}
+	return attr, nil
+}
+
+// stringElements extracts every element of tup as a plain string
+// literal, in source order. Anything other than a bare quoted string
+// (e.g. a variable reference or interpolation) is rejected so the
+// renderer never silently rewrites a computed list.
+func stringElements(tup *hclsyntax.TupleConsExpr) ([]string, error) {
+	out := make([]string, 0, len(tup.Exprs))
+	for i, e := range tup.Exprs {
+		te, ok := e.(*hclsyntax.TemplateExpr)
+		if !ok || !te.IsStringLiteral() {
+			return nil, fmt.Errorf("logos_workspaces[%d]: must be a plain string literal", i)
+		}
+		v, diags := te.Value(nil)
+		if diags.HasErrors() {
+			return nil, fmt.Errorf("logos_workspaces[%d]: %s", i, diags.Error())
+		}
+		if v.Type().FriendlyName() != "string" {
+			return nil, fmt.Errorf("logos_workspaces[%d]: not a string", i)
+		}
+		out = append(out, v.AsString())
+	}
+	return out, nil
+}
+
+// alphaInsertIndex returns the index at which workspace should be
+// inserted to keep values sorted, when values is already sorted. When
+// values is not sorted, the returned index is len(values) so the new
+// entry is appended rather than guessing where it would belong.
+func alphaInsertIndex(values []string, workspace string) int {
+	if !sort.StringsAreSorted(values) {
+		return len(values)
+	}
+	return sort.SearchStrings(values, workspace)
+}
+
+// detectEOL returns "\r\n" if any CRLF line endings appear in src,
+// otherwise "\n". helpers.tofu in the foundation repos uses LF; CRLF
+// support is a defensive measure for inputs that came through a
+// CRLF-converting transport.
+func detectEOL(src []byte) string {
+	if bytes.Contains(src, []byte("\r\n")) {
+		return "\r\n"
+	}
+	return "\n"
+}
+
+// elementIndent returns the leading whitespace on the line that
+// contains the element at r. Used to indent the new element identically
+// to the existing entries.
+func elementIndent(src []byte, r hcl.Range) string {
+	start := r.Start.Byte
+	if start <= 0 || start > len(src) {
+		return ""
+	}
+	lineStart := bytes.LastIndexByte(src[:start], '\n') + 1
+	prefix := src[lineStart:start]
+	for i := 0; i < len(prefix); i++ {
+		if prefix[i] != ' ' && prefix[i] != '\t' {
+			return string(prefix[:i])
+		}
+	}
+	return string(prefix)
+}
+
+// insertBefore splices a new line for workspace immediately before the
+// element at r. The new line carries a trailing comma so the element
+// after it remains formatted as it was.
+func insertBefore(src []byte, r hcl.Range, workspace, indent, eol string) []byte {
+	lineStart := bytes.LastIndexByte(src[:r.Start.Byte], '\n') + 1
+	insertion := []byte(indent + `"` + workspace + `",` + eol)
+	return spliceAt(src, lineStart, insertion)
+}
+
+// appendAfterLast inserts workspace as a new last element. Two cases:
+//   - The list already has a trailing comma after the previous last
+//     element: insert a fully-terminated line right after that comma's
+//     line.
+//   - The list does NOT have a trailing comma: insert
+//     ",<eol><indent><quoted>" right after the previous last element,
+//     which both adds the missing comma to the previous element and
+//     writes the new element with no trailing comma — preserving the
+//     no-trailing-comma style.
+func appendAfterLast(src []byte, tup *hclsyntax.TupleConsExpr, workspace, indent, eol string) ([]byte, error) {
+	last := tup.Exprs[len(tup.Exprs)-1]
+	endByte := last.Range().End.Byte
+	if endByte > len(src) {
+		return nil, fmt.Errorf("internal: last element end byte %d out of range", endByte)
+	}
+	hasTrailingComma := false
+	for i := endByte; i < tup.Range().End.Byte && i < len(src); i++ {
+		c := src[i]
+		if c == ',' {
+			hasTrailingComma = true
+			break
+		}
+		if c == ' ' || c == '\t' || c == '\r' || c == '\n' {
+			continue
+		}
+		// Anything else (including the closing ']') means we passed the
+		// post-element gap with no comma found.
+		break
+	}
+
+	var insertion []byte
+	var insertAt int
+	if hasTrailingComma {
+		// Insert a new well-formed line after the line containing the
+		// trailing comma, so the new element also ends with a comma.
+		commaLineEnd := bytes.IndexByte(src[endByte:], '\n')
+		if commaLineEnd < 0 {
+			return nil, fmt.Errorf("internal: no newline after trailing comma")
+		}
+		insertAt = endByte + commaLineEnd + 1
+		insertion = []byte(indent + `"` + workspace + `",` + eol)
+	} else {
+		// Add the missing comma to the previous element and write the
+		// new element with no trailing comma to preserve the style.
+		insertAt = endByte
+		insertion = []byte("," + eol + indent + `"` + workspace + `"`)
+	}
+	return spliceAt(src, insertAt, insertion), nil
+}
+
+// spliceAt inserts ins into src at byte offset off. Returns a fresh
+// slice; src is not mutated.
+func spliceAt(src []byte, off int, ins []byte) []byte {
+	out := make([]byte, 0, len(src)+len(ins))
+	out = append(out, src[:off]...)
+	out = append(out, ins...)
+	out = append(out, src[off:]...)
+	return out
+}

--- a/internal/helpersrender/render_test.go
+++ b/internal/helpersrender/render_test.go
@@ -234,6 +234,14 @@ module "core_helpers" { logos_workspaces = ["b"] }
 			wantSub: `cannot infer style for insertion`,
 		},
 		{
+			name: "inline list",
+			src: `module "core_helpers" {
+  logos_workspaces = ["pt-corpus-main-production", "pt-logos-main-production"]
+}
+`,
+			wantSub: `one element per line`,
+		},
+		{
 			name:    "empty workspace input",
 			src:     ptCorpusFixture,
 			wantSub: `workspace is empty`,

--- a/internal/helpersrender/render_test.go
+++ b/internal/helpersrender/render_test.go
@@ -1,0 +1,257 @@
+package helpersrender
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+// ptCorpusFixture mirrors osinfra-io/pt-corpus/helpers.tofu — sorted
+// list, no trailing comma on the last element, two-space indentation.
+const ptCorpusFixture = `# OpenTofu Core Helpers Module (osinfra.io)
+# https://github.com/osinfra-io/pt-arche-core-helpers
+
+module "core_helpers" {
+  source = "github.com/osinfra-io/pt-arche-core-helpers//root?ref=70c1e4f4a11acdcfc36055bdd3aa16579d4203a1" # v0.3.1
+
+  cost_center         = "x001"
+  data_classification = "public"
+
+  # Logos functionality - consolidated into core-helpers
+  logos_workspaces = [
+    "pt-corpus-main-production",
+    "pt-kryptos-main-production",
+    "pt-logos-main-production",
+    "pt-pneuma-main-production",
+    "pt-techne-main-production",
+    "st-ethos-main-production"
+  ]
+
+  repository = "pt-corpus"
+  team       = "pt-corpus"
+}
+`
+
+// ptPneumaFixture mirrors osinfra-io/pt-pneuma/helpers.tofu — sorted
+// list with a trailing comma on the last element.
+const ptPneumaFixture = `module "core_helpers" {
+  source = "github.com/osinfra-io/pt-arche-core-helpers//root?ref=70c1e4f4a11acdcfc36055bdd3aa16579d4203a1" # v0.3.1
+
+  logos_workspaces = [
+    "pt-corpus-main-production",
+    "pt-kryptos-main-production",
+    "pt-logos-main-production",
+    "pt-pneuma-main-production",
+  ]
+
+  repository = "pt-pneuma"
+  team       = "pt-pneuma"
+}
+`
+
+func TestRender_InsertSorted_NoTrailingComma(t *testing.T) {
+	out, err := Render([]byte(ptCorpusFixture), "pt-newteam-main-production")
+	if err != nil {
+		t.Fatalf("Render: %v", err)
+	}
+	want := strings.Replace(
+		ptCorpusFixture,
+		`    "pt-pneuma-main-production",`,
+		"    \"pt-newteam-main-production\",\n    \"pt-pneuma-main-production\",",
+		1,
+	)
+	if string(out) != want {
+		t.Fatalf("output mismatch\n--- got ---\n%s\n--- want ---\n%s", out, want)
+	}
+}
+
+func TestRender_InsertSorted_TrailingComma(t *testing.T) {
+	out, err := Render([]byte(ptPneumaFixture), "pt-newteam-main-production")
+	if err != nil {
+		t.Fatalf("Render: %v", err)
+	}
+	want := strings.Replace(
+		ptPneumaFixture,
+		`    "pt-pneuma-main-production",`,
+		"    \"pt-newteam-main-production\",\n    \"pt-pneuma-main-production\",",
+		1,
+	)
+	if string(out) != want {
+		t.Fatalf("output mismatch\n--- got ---\n%s\n--- want ---\n%s", out, want)
+	}
+}
+
+func TestRender_AppendAtEnd_NoTrailingComma(t *testing.T) {
+	// "zz-..." sorts after every existing entry → must be appended at
+	// the end, and the previous last element gains a comma.
+	out, err := Render([]byte(ptCorpusFixture), "zz-newteam-main-production")
+	if err != nil {
+		t.Fatalf("Render: %v", err)
+	}
+	want := strings.Replace(
+		ptCorpusFixture,
+		"    \"st-ethos-main-production\"\n  ]",
+		"    \"st-ethos-main-production\",\n    \"zz-newteam-main-production\"\n  ]",
+		1,
+	)
+	if string(out) != want {
+		t.Fatalf("output mismatch\n--- got ---\n%s\n--- want ---\n%s", out, want)
+	}
+}
+
+func TestRender_AppendAtEnd_TrailingComma(t *testing.T) {
+	out, err := Render([]byte(ptPneumaFixture), "zz-newteam-main-production")
+	if err != nil {
+		t.Fatalf("Render: %v", err)
+	}
+	want := strings.Replace(
+		ptPneumaFixture,
+		"    \"pt-pneuma-main-production\",\n  ]",
+		"    \"pt-pneuma-main-production\",\n    \"zz-newteam-main-production\",\n  ]",
+		1,
+	)
+	if string(out) != want {
+		t.Fatalf("output mismatch\n--- got ---\n%s\n--- want ---\n%s", out, want)
+	}
+}
+
+func TestRender_Idempotent_BytesIdentical(t *testing.T) {
+	for name, src := range map[string]string{
+		"pt-corpus": ptCorpusFixture,
+		"pt-pneuma": ptPneumaFixture,
+	} {
+		t.Run(name, func(t *testing.T) {
+			in := []byte(src)
+			out, err := Render(in, "pt-logos-main-production")
+			if err != nil {
+				t.Fatalf("Render: %v", err)
+			}
+			if !bytes.Equal(in, out) {
+				t.Fatalf("noop must return byte-identical output\n--- in ---\n%s\n--- out ---\n%s", in, out)
+			}
+		})
+	}
+}
+
+func TestRender_AppendWhenUnsorted(t *testing.T) {
+	src := `module "core_helpers" {
+  logos_workspaces = [
+    "pt-zeta-main-production",
+    "pt-alpha-main-production",
+  ]
+}
+`
+	out, err := Render([]byte(src), "pt-mid-main-production")
+	if err != nil {
+		t.Fatalf("Render: %v", err)
+	}
+	// "pt-mid-..." would land between alpha and zeta if sorted — but
+	// the existing list is unsorted, so we append at the end instead.
+	want := `module "core_helpers" {
+  logos_workspaces = [
+    "pt-zeta-main-production",
+    "pt-alpha-main-production",
+    "pt-mid-main-production",
+  ]
+}
+`
+	if string(out) != want {
+		t.Fatalf("output mismatch\n--- got ---\n%s\n--- want ---\n%s", out, want)
+	}
+}
+
+func TestRender_PreservesCRLF(t *testing.T) {
+	src := strings.ReplaceAll(ptPneumaFixture, "\n", "\r\n")
+	out, err := Render([]byte(src), "pt-newteam-main-production")
+	if err != nil {
+		t.Fatalf("Render: %v", err)
+	}
+	if !bytes.Contains(out, []byte("\r\n    \"pt-newteam-main-production\",\r\n    \"pt-pneuma-main-production\",\r\n")) {
+		t.Fatalf("CRLF not preserved around inserted line:\n%s", out)
+	}
+	if bytes.Contains(out, []byte("    \"pt-newteam-main-production\",\n    ")) {
+		t.Fatalf("LF leaked into a CRLF input:\n%s", out)
+	}
+}
+
+func TestRender_Errors(t *testing.T) {
+	cases := []struct {
+		name    string
+		src     string
+		wantSub string
+	}{
+		{
+			name:    "missing module",
+			src:     `foo = "bar"` + "\n",
+			wantSub: `module "core_helpers" block not found`,
+		},
+		{
+			name: "duplicate module",
+			src: `module "core_helpers" { logos_workspaces = ["a"] }
+module "core_helpers" { logos_workspaces = ["b"] }
+`,
+			wantSub: `multiple module "core_helpers" blocks`,
+		},
+		{
+			name: "missing attribute",
+			src: `module "core_helpers" {
+  source = "x"
+}
+`,
+			wantSub: `logos_workspaces attribute not found`,
+		},
+		{
+			name: "non-list value",
+			src: `module "core_helpers" {
+  logos_workspaces = "not-a-list"
+}
+`,
+			wantSub: `must be a list literal`,
+		},
+		{
+			name: "non-string element",
+			src: `module "core_helpers" {
+  logos_workspaces = ["ok", 42]
+}
+`,
+			wantSub: `must be a plain string literal`,
+		},
+		{
+			name: "interpolation element",
+			src: `module "core_helpers" {
+  prefix           = "pt"
+  logos_workspaces = ["${prefix}-corpus-main-production"]
+}
+`,
+			wantSub: `must be a plain string literal`,
+		},
+		{
+			name: "empty list",
+			src: `module "core_helpers" {
+  logos_workspaces = []
+}
+`,
+			wantSub: `cannot infer style for insertion`,
+		},
+		{
+			name:    "empty workspace input",
+			src:     ptCorpusFixture,
+			wantSub: `workspace is empty`,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ws := "pt-new-main-production"
+			if tc.name == "empty workspace input" {
+				ws = ""
+			}
+			_, err := Render([]byte(tc.src), ws)
+			if err == nil {
+				t.Fatalf("expected error containing %q, got nil", tc.wantSub)
+			}
+			if !strings.Contains(err.Error(), tc.wantSub) {
+				t.Fatalf("error %q does not contain %q", err.Error(), tc.wantSub)
+			}
+		})
+	}
+}

--- a/internal/tools/open_team_pr_test.go
+++ b/internal/tools/open_team_pr_test.go
@@ -24,6 +24,7 @@ import (
 type fakeClient struct {
 	refs       map[string]string // branch -> SHA
 	files      map[string]string // path@ref -> content (blob SHA == content here for simplicity)
+	repoFiles  map[string]string // repo/path@ref -> content (sibling-repo reads via GetFileInRepo)
 	openPRs    []gh.PullRequest
 	compareRes gh.CompareStatus
 
@@ -38,9 +39,10 @@ type fakeClient struct {
 
 func newFake() *fakeClient {
 	return &fakeClient{
-		refs:    map[string]string{"main": "main-sha"},
-		files:   map[string]string{},
-		openPRs: nil,
+		refs:      map[string]string{"main": "main-sha"},
+		files:     map[string]string{},
+		repoFiles: map[string]string{},
+		openPRs:   nil,
 	}
 }
 
@@ -76,6 +78,14 @@ func (f *fakeClient) CompareCommits(_ context.Context, _, _ string) (gh.CompareS
 
 func (f *fakeClient) GetFile(_ context.Context, path, ref string) ([]byte, string, bool, error) {
 	v, ok := f.files[path+"@"+ref]
+	if !ok {
+		return nil, "", false, nil
+	}
+	return []byte(v), "blob-" + v, true, nil
+}
+
+func (f *fakeClient) GetFileInRepo(_ context.Context, repo, path, ref string) ([]byte, string, bool, error) {
+	v, ok := f.repoFiles[repo+"/"+path+"@"+ref]
 	if !ok {
 		return nil, "", false, nil
 	}

--- a/internal/tools/render_corpus_helpers.go
+++ b/internal/tools/render_corpus_helpers.go
@@ -1,0 +1,64 @@
+// MCP tool: render_corpus_helpers.
+//
+// Fetches helpers.tofu from osinfra-io/pt-corpus@main, inserts the
+// team's main-production workspace into the logos_workspaces list, and
+// returns the canonical updated bytes. Idempotent: returns the input
+// bytes unchanged when the workspace is already present.
+package tools
+
+import (
+	"context"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+
+	gh "github.com/osinfra-io/pt-techne-mcp-server/internal/github"
+	"github.com/osinfra-io/pt-techne-mcp-server/internal/helpersrender"
+)
+
+// RenderCorpusHelpersInput is the input for render_corpus_helpers.
+type RenderCorpusHelpersInput struct {
+	TeamKey string `json:"team_key" jsonschema:"the team key, e.g. 'pt-arche'. Must match ^(pt|st|ct|et)-[a-z][a-z0-9-]*[a-z0-9]$"`
+}
+
+// RenderCorpusHelpersOutput is the structured result.
+type RenderCorpusHelpersOutput struct {
+	HelpersTofu string `json:"helpers_tofu"`
+}
+
+// RenderCorpusHelpers registers the render_corpus_helpers tool.
+// Requires GITHUB_TOKEN with read access to osinfra-io/pt-corpus.
+func RenderCorpusHelpers(s *mcp.Server, c gh.Client) {
+	mcp.AddTool(s, &mcp.Tool{
+		Name:        "render_corpus_helpers",
+		Description: "Fetch helpers.tofu from osinfra-io/pt-corpus@main and return canonical bytes with '<team_key>-main-production' inserted into logos_workspaces. Idempotent: returns the input bytes unchanged when the workspace is already present. Requires GITHUB_TOKEN.",
+	}, func(ctx context.Context, _ *mcp.CallToolRequest, in RenderCorpusHelpersInput) (*mcp.CallToolResult, *RenderCorpusHelpersOutput, error) {
+		return renderHelpersTool(ctx, c, "render_corpus_helpers", "pt-corpus", in.TeamKey, func(b []byte) *RenderCorpusHelpersOutput {
+			return &RenderCorpusHelpersOutput{HelpersTofu: string(b)}
+		})
+	})
+}
+
+// renderHelpersTool is the shared body for render_corpus_helpers and
+// render_pneuma_helpers. Inlined into both adapters via a generic
+// callback so the typed output struct stays per-tool (the MCP SDK
+// derives schemas from the concrete struct).
+func renderHelpersTool[T any](ctx context.Context, c gh.Client, toolName, repo, teamKey string, wrap func([]byte) *T) (*mcp.CallToolResult, *T, error) {
+	if c == nil {
+		return notConfigured(toolName), nil, nil
+	}
+	if !teamKeyRe.MatchString(teamKey) {
+		return errResult(opError{Code: "invalid_input", Message: "team_key must match ^(pt|st|ct|et)-[a-z][a-z0-9-]*[a-z0-9]$"}), nil, nil
+	}
+	body, _, exists, err := c.GetFileInRepo(ctx, repo, "helpers.tofu", gh.Base)
+	if err != nil {
+		return errResult(*apiError(err)), nil, nil
+	}
+	if !exists {
+		return errResult(opError{Code: "source_parse_error", Message: "helpers.tofu missing at " + repo + "@" + gh.Base}), nil, nil
+	}
+	out, rerr := helpersrender.Render(body, teamKey+"-main-production")
+	if rerr != nil {
+		return errResult(opError{Code: "source_parse_error", Message: repo + "/helpers.tofu: " + rerr.Error()}), nil, nil
+	}
+	return nil, wrap(out), nil
+}

--- a/internal/tools/render_helpers_test.go
+++ b/internal/tools/render_helpers_test.go
@@ -1,0 +1,193 @@
+package tools_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+
+	gh "github.com/osinfra-io/pt-techne-mcp-server/internal/github"
+	"github.com/osinfra-io/pt-techne-mcp-server/internal/tools"
+)
+
+// helpersHarness wires the two helpers-renderer tools against a fake
+// gh.Client. Mirrors readToolHarness but isolated because these tools
+// don't share the readToolHarness's pt-logos teams seeding.
+type helpersHarness struct {
+	t  *testing.T
+	cs *mcp.ClientSession
+}
+
+func newHelpersHarness(t *testing.T, c gh.Client) *helpersHarness {
+	t.Helper()
+	server := mcp.NewServer(&mcp.Implementation{Name: "test"}, nil)
+	tools.RenderCorpusHelpers(server, c)
+	tools.RenderPneumaHelpers(server, c)
+
+	ct, st := mcp.NewInMemoryTransports()
+	ctx := context.Background()
+	if _, err := server.Connect(ctx, st, nil); err != nil {
+		t.Fatalf("server.Connect: %v", err)
+	}
+	client := mcp.NewClient(&mcp.Implementation{Name: "test-client"}, nil)
+	cs, err := client.Connect(ctx, ct, nil)
+	if err != nil {
+		t.Fatalf("client.Connect: %v", err)
+	}
+	t.Cleanup(func() { cs.Close() })
+	return &helpersHarness{t: t, cs: cs}
+}
+
+func (h *helpersHarness) call(name string, args any) *mcp.CallToolResult {
+	h.t.Helper()
+	res, err := h.cs.CallTool(context.Background(), &mcp.CallToolParams{Name: name, Arguments: args})
+	if err != nil {
+		h.t.Fatalf("CallTool %s: %v", name, err)
+	}
+	return res
+}
+
+const corpusHelpersFixture = `module "core_helpers" {
+  source = "github.com/osinfra-io/pt-arche-core-helpers//root?ref=70c1e4f4a11acdcfc36055bdd3aa16579d4203a1" # v0.3.1
+
+  logos_workspaces = [
+    "pt-corpus-main-production",
+    "pt-logos-main-production",
+    "pt-pneuma-main-production"
+  ]
+
+  repository = "pt-corpus"
+  team       = "pt-corpus"
+}
+`
+
+const pneumaHelpersFixture = `module "core_helpers" {
+  logos_workspaces = [
+    "pt-corpus-main-production",
+    "pt-logos-main-production",
+    "pt-pneuma-main-production",
+  ]
+
+  repository = "pt-pneuma"
+  team       = "pt-pneuma"
+}
+`
+
+func seedHelpersFake() *fakeClient {
+	f := newFake()
+	f.repoFiles["pt-corpus/helpers.tofu@main"] = corpusHelpersFixture
+	f.repoFiles["pt-pneuma/helpers.tofu@main"] = pneumaHelpersFixture
+	return f
+}
+
+func TestRenderCorpusHelpers_Insert(t *testing.T) {
+	h := newHelpersHarness(t, seedHelpersFake())
+	res := h.call("render_corpus_helpers", map[string]any{"team_key": "pt-newteam"})
+	var out tools.RenderCorpusHelpersOutput
+	decodeStruct(t, res, &out)
+	if !strings.Contains(out.HelpersTofu, `"pt-newteam-main-production",`) {
+		t.Fatalf("inserted line not found:\n%s", out.HelpersTofu)
+	}
+	// Sorted insert position: between pt-logos and pt-pneuma.
+	wantOrder := []string{
+		`"pt-corpus-main-production"`,
+		`"pt-logos-main-production"`,
+		`"pt-newteam-main-production"`,
+		`"pt-pneuma-main-production"`,
+	}
+	prev := -1
+	for _, s := range wantOrder {
+		idx := strings.Index(out.HelpersTofu, s)
+		if idx < 0 {
+			t.Fatalf("missing %s in output:\n%s", s, out.HelpersTofu)
+		}
+		if idx <= prev {
+			t.Fatalf("entries out of order; %s appeared before previous entry", s)
+		}
+		prev = idx
+	}
+}
+
+func TestRenderPneumaHelpers_Insert(t *testing.T) {
+	h := newHelpersHarness(t, seedHelpersFake())
+	res := h.call("render_pneuma_helpers", map[string]any{"team_key": "pt-newteam"})
+	var out tools.RenderPneumaHelpersOutput
+	decodeStruct(t, res, &out)
+	if !strings.Contains(out.HelpersTofu, `    "pt-newteam-main-production",`) {
+		t.Fatalf("inserted line not found:\n%s", out.HelpersTofu)
+	}
+	if !strings.Contains(out.HelpersTofu, `    "pt-pneuma-main-production",`+"\n  ]") {
+		t.Fatalf("trailing-comma style not preserved:\n%s", out.HelpersTofu)
+	}
+}
+
+func TestRenderHelpers_Idempotent(t *testing.T) {
+	h := newHelpersHarness(t, seedHelpersFake())
+
+	res := h.call("render_corpus_helpers", map[string]any{"team_key": "pt-logos"})
+	var corpusOut tools.RenderCorpusHelpersOutput
+	decodeStruct(t, res, &corpusOut)
+	if corpusOut.HelpersTofu != corpusHelpersFixture {
+		t.Fatalf("noop must return byte-identical helpers.tofu\n--- got ---\n%s\n--- want ---\n%s", corpusOut.HelpersTofu, corpusHelpersFixture)
+	}
+
+	res = h.call("render_pneuma_helpers", map[string]any{"team_key": "pt-pneuma"})
+	var pneumaOut tools.RenderPneumaHelpersOutput
+	decodeStruct(t, res, &pneumaOut)
+	if pneumaOut.HelpersTofu != pneumaHelpersFixture {
+		t.Fatalf("noop must return byte-identical helpers.tofu\n--- got ---\n%s\n--- want ---\n%s", pneumaOut.HelpersTofu, pneumaHelpersFixture)
+	}
+}
+
+func TestRenderHelpers_NotConfigured(t *testing.T) {
+	h := newHelpersHarness(t, nil)
+	for _, name := range []string{"render_corpus_helpers", "render_pneuma_helpers"} {
+		t.Run(name, func(t *testing.T) {
+			res := h.call(name, map[string]any{"team_key": "pt-newteam"})
+			body := decodeError(t, res)
+			if body["code"] != "not_configured" {
+				t.Fatalf("expected not_configured, got %+v", body)
+			}
+		})
+	}
+}
+
+func TestRenderHelpers_InvalidInput(t *testing.T) {
+	h := newHelpersHarness(t, seedHelpersFake())
+	for _, bad := range []string{"", "no-prefix", "pt-", "pt-Foo", "PT-bar"} {
+		t.Run(bad, func(t *testing.T) {
+			res := h.call("render_corpus_helpers", map[string]any{"team_key": bad})
+			body := decodeError(t, res)
+			if body["code"] != "invalid_input" {
+				t.Fatalf("expected invalid_input for %q, got %+v", bad, body)
+			}
+		})
+	}
+}
+
+func TestRenderHelpers_FileMissing(t *testing.T) {
+	f := newFake() // no repoFiles seeded
+	h := newHelpersHarness(t, f)
+	res := h.call("render_corpus_helpers", map[string]any{"team_key": "pt-newteam"})
+	body := decodeError(t, res)
+	if body["code"] != "source_parse_error" {
+		t.Fatalf("expected source_parse_error, got %+v", body)
+	}
+	if !strings.Contains(body["message"].(string), "missing") {
+		t.Fatalf("expected 'missing' in message, got %v", body["message"])
+	}
+}
+
+func TestRenderHelpers_MalformedSource(t *testing.T) {
+	f := newFake()
+	f.repoFiles["pt-corpus/helpers.tofu@main"] = `# no module block here
+foo = "bar"
+`
+	h := newHelpersHarness(t, f)
+	res := h.call("render_corpus_helpers", map[string]any{"team_key": "pt-newteam"})
+	body := decodeError(t, res)
+	if body["code"] != "source_parse_error" {
+		t.Fatalf("expected source_parse_error, got %+v", body)
+	}
+}

--- a/internal/tools/render_pneuma_helpers.go
+++ b/internal/tools/render_pneuma_helpers.go
@@ -1,0 +1,38 @@
+// MCP tool: render_pneuma_helpers.
+//
+// Fetches helpers.tofu from osinfra-io/pt-pneuma@main, inserts the
+// team's main-production workspace into the logos_workspaces list, and
+// returns the canonical updated bytes. Idempotent: returns the input
+// bytes unchanged when the workspace is already present.
+package tools
+
+import (
+	"context"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+
+	gh "github.com/osinfra-io/pt-techne-mcp-server/internal/github"
+)
+
+// RenderPneumaHelpersInput is the input for render_pneuma_helpers.
+type RenderPneumaHelpersInput struct {
+	TeamKey string `json:"team_key" jsonschema:"the team key, e.g. 'pt-arche'. Must match ^(pt|st|ct|et)-[a-z][a-z0-9-]*[a-z0-9]$"`
+}
+
+// RenderPneumaHelpersOutput is the structured result.
+type RenderPneumaHelpersOutput struct {
+	HelpersTofu string `json:"helpers_tofu"`
+}
+
+// RenderPneumaHelpers registers the render_pneuma_helpers tool.
+// Requires GITHUB_TOKEN with read access to osinfra-io/pt-pneuma.
+func RenderPneumaHelpers(s *mcp.Server, c gh.Client) {
+	mcp.AddTool(s, &mcp.Tool{
+		Name:        "render_pneuma_helpers",
+		Description: "Fetch helpers.tofu from osinfra-io/pt-pneuma@main and return canonical bytes with '<team_key>-main-production' inserted into logos_workspaces. Idempotent: returns the input bytes unchanged when the workspace is already present. Requires GITHUB_TOKEN.",
+	}, func(ctx context.Context, _ *mcp.CallToolRequest, in RenderPneumaHelpersInput) (*mcp.CallToolResult, *RenderPneumaHelpersOutput, error) {
+		return renderHelpersTool(ctx, c, "render_pneuma_helpers", "pt-pneuma", in.TeamKey, func(b []byte) *RenderPneumaHelpersOutput {
+			return &RenderPneumaHelpersOutput{HelpersTofu: string(b)}
+		})
+	})
+}

--- a/internal/tools/team_key.go
+++ b/internal/tools/team_key.go
@@ -1,0 +1,8 @@
+// teamKeyRe matches the same pattern as schema/team.schema.json's
+// team_key. Used by tools that accept a team_key directly (e.g. the
+// helpers renderers) and never call the validator.
+package tools
+
+import "regexp"
+
+var teamKeyRe = regexp.MustCompile(`^(pt|st|ct|et)-[a-z][a-z0-9-]*[a-z0-9]$`)


### PR DESCRIPTION
Closes part of #6 (Phase 4 — cross-repo helpers renderers).

## What

Two new MCP tools that surgically insert `<team_key>-main-production` into the `logos_workspaces` list of `helpers.tofu` in `pt-corpus` and `pt-pneuma`:

| Tool | Input | Output |
|---|---|---|
| `render_corpus_helpers` | `{team_key}` | `{helpers_tofu}` |
| `render_pneuma_helpers` | `{team_key}` | `{helpers_tofu}` |

Both fetch the existing `helpers.tofu` from the target repo via the GitHub API, splice in one new line, and return the canonical updated bytes. No writes — the agent lands the change with the same tooling it uses for any other `helpers.tofu` edit.

## How

- **`internal/helpersrender/`** — byte-splice renderer. Parses with `hashicorp/hcl/v2/hclsyntax` to locate the single `module "core_helpers"` block and its `logos_workspaces` attribute, then byte-splices a new line in. Contract:
  - **Idempotent.** Workspace already present → input bytes returned unchanged (byte-identical).
  - **Minimal diff.** Only the new line is added; existing entries, comments, indentation, line-ending style (LF/CRLF), and trailing-comma convention are preserved exactly.
  - **Strict input.** Exactly one `module "core_helpers"` block with exactly one `logos_workspaces` attribute that is a list of plain string literals; anything else → `source_parse_error`.
  - **Insert position.** Alphabetical when the existing list is sorted; appended otherwise. Never reorders existing entries.
- **`internal/github.Client.GetFileInRepo`** — first cross-repo read on the GitHub client. Write surface remains pt-logos-only.
- **`internal/tools/render_{corpus,pneuma}_helpers.go`** — thin MCP adapters. `team_key` validated against the same regex as `schema/team.schema.json`.

## Op-error codes

| Code | When |
|---|---|
| `not_configured` | `GITHUB_TOKEN` not set |
| `invalid_input` | `team_key` doesn't match the schema regex |
| `source_parse_error` | `helpers.tofu` missing, malformed, or not in the expected shape |
| `github_api_error` | Transport / 5xx |

## Token scope

Caveat documented in `README.md`: granting Read on `pt-corpus`/`pt-pneuma` alongside Read+Write on `pt-logos` requires either accepting Read+Write on all three or splitting tokens (App/PAT permissions are not per-repo).

## Out of scope (deferred)

- `open_corpus_pr` / `open_pneuma_pr`
- `get_team_resources`

## Verification

```
$ make all
go vet ./...
staticcheck ./...
go test -race ./...
ok  	github.com/osinfra-io/pt-techne-mcp-server/internal/github	1.012s
ok  	github.com/osinfra-io/pt-techne-mcp-server/internal/helpersrender	1.017s
ok  	github.com/osinfra-io/pt-techne-mcp-server/internal/render	(cached)
ok  	github.com/osinfra-io/pt-techne-mcp-server/internal/spec	(cached)
ok  	github.com/osinfra-io/pt-techne-mcp-server/internal/tools	(cached)
go build -o bin/pt-techne-mcp-server ./cmd/pt-techne-mcp-server
```

Renderer tests cover: insert-into-sorted, append-when-unsorted, idempotent noop, trailing-comma preservation, no-trailing-comma preservation, CRLF preservation, missing block, missing attribute.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added two tools to fetch and produce updated helpers configuration for corpus and pneuma repositories; both preserve formatting and are idempotent.

* **Documentation**
  * Updated GitHub token guidance to require read access to the corpus and pneuma repos and clarified auth recommendations.

* **Improvements**
  * Expanded error codes and validation to give clearer helpers-specific failure messages.

* **Tests**
  * Added comprehensive tests covering insertion behavior, idempotence, formatting preservation, CRLF handling, and error cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->