### PR TITLE
Add ekklesia-docs renderer tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,11 +12,14 @@ Model Context Protocol (MCP) server providing platform context and tools to AI a
 | `render_team_tfvars` | `{spec: <object>}` | `{tfvars: string}` (canonical pt-logos `.tfvars` bytes) |
 | `open_team_pr` | `{spec: <object>, message?: string}` | `{pr_url, pr_number, branch, commit_sha, action}` |
 | `list_teams` | `{}` | `{teams: [{team_key, display_name, team_type, member_count, repo_count, env_count}]}` |
-| `get_team` | `{team_key: string}` | `{spec: <object>}` (same shape `validate_team_spec` accepts) |
+| `get_team` | `{team_key: string}` | `{spec: <object>, docs_pages: [string]}` (`spec` matches `validate_team_spec`; `docs_pages` lists existing pages under `docs/<section>/<team>/` in `pt-ekklesia-docs@main`, excluding `index.md`) |
 | `lookup_user` | `{github_username: string} \| {email: string}` | `{matches: [{team_key, via, system, scope, subject, membership}]}` |
 | `find_repo` | `{name: string}` | `{matches: [{team_key, repository: <object>}]}` |
 | `render_corpus_helpers` | `{team_key: string}` | `{helpers_tofu: string}` (canonical `pt-corpus/helpers.tofu` bytes with `<team_key>-main-production` inserted) |
 | `render_pneuma_helpers` | `{team_key: string}` | `{helpers_tofu: string}` (same, for `pt-pneuma/helpers.tofu`) |
+| `render_team_docs_index` | `{spec: <object>}` | `{path, content}` (`docs/<section>/<team>/index.md` for pt-ekklesia-docs) |
+| `render_sidebar_patch` | `{spec: <object>, current_sidebars_js: string}` | `{content}` (patched `pt-ekklesia-docs/sidebars.js`) |
+| `open_team_docs_pr` | `{spec: <object>, message?: string}` | `{pr_url, pr_number, branch, commit_shas, action, index_path, sidebars_path}` |
 
 `render_team_tfvars` validates first; on failure it returns an MCP `isError` result with the same structured errors as `validate_team_spec`.
 
@@ -30,22 +33,27 @@ Model Context Protocol (MCP) server providing platform context and tools to AI a
 
 `render_corpus_helpers` and `render_pneuma_helpers` fetch `helpers.tofu` from `osinfra-io/pt-corpus@main` and `osinfra-io/pt-pneuma@main` respectively, insert `<team_key>-main-production` into the `logos_workspaces` list inside the `module "core_helpers"` block, and return the canonical updated file bytes. They are **idempotent**: when the workspace is already present, the input bytes are returned byte-identical. They preserve every other byte of the file (comments, indentation, line-ending style, trailing-comma convention) and refuse to rewrite a file whose `logos_workspaces` is anything other than a list of plain string literals (returns `source_parse_error`). These tools produce bytes only — they do not open PRs; the caller (or a follow-up tool) is responsible for landing the change.
 
+`render_team_docs_index` and `render_sidebar_patch` produce the two artifacts a new team needs in `osinfra-io/pt-ekklesia-docs`: a `docs/<section>/<team>/index.md` page (frontmatter + heading + the team's `display_name_comment` as the lede) and a patched `sidebars.js` with the page registered under the right section. The sidebar patcher is **anchor-driven** — it relies on `// region: <section>` / `// endregion: <section>` markers in `sidebars.js` and returns `source_parse_error` when they are missing. Both renderers are byte-stable noops when the artifact already matches. Section is derived from `team_type`; team folder is derived from `team_key` (prefix stripped). The page body intentionally stays minimal — Bounded Context, Ubiquitous Language, ADRs, and so on remain human-authored.
+
+`open_team_docs_pr` runs both docs renderers and lands them on `team-docs/<team_key>` in `osinfra-io/pt-ekklesia-docs` via the same idempotent transaction as `open_team_pr` (per-file commits, noop when the branch and PR already match).
+
 ## Configuration
 
 ### `GITHUB_TOKEN`
 
-Required by `open_team_pr`, the four pt-logos read tools (`list_teams`, `get_team`, `lookup_user`, `find_repo`), and the two helpers renderers (`render_corpus_helpers`, `render_pneuma_helpers`). Without it the server still serves `validate_team_spec` and `render_team_tfvars`; the GitHub-backed tools return a structured `not_configured` error.
+Required by `open_team_pr`, the four pt-logos read tools (`list_teams`, `get_team`, `lookup_user`, `find_repo`), the two helpers renderers (`render_corpus_helpers`, `render_pneuma_helpers`), and `open_team_docs_pr`. Without it the server still serves `validate_team_spec`, `render_team_tfvars`, `render_team_docs_index`, and `render_sidebar_patch`; the GitHub-backed tools return a structured `not_configured` error.
 
-The token must be scoped to **`osinfra-io/pt-logos`**, **`osinfra-io/pt-corpus`**, and **`osinfra-io/pt-pneuma`** with the following permissions:
+The token must be scoped to **`osinfra-io/pt-logos`**, **`osinfra-io/pt-corpus`**, **`osinfra-io/pt-pneuma`**, and **`osinfra-io/pt-ekklesia-docs`** with the following permissions:
 
 - On `pt-logos`: **Contents — read and write**, **Pull requests — read and write** (used by `open_team_pr` plus the four read tools).
 - On `pt-corpus` and `pt-pneuma`: **Contents — read** (used by `render_corpus_helpers` and `render_pneuma_helpers` to fetch `helpers.tofu`).
+- On `pt-ekklesia-docs`: **Contents — read and write**, **Pull requests — read and write** (used by `open_team_docs_pr` to land the docs index page + sidebars patch, and by `get_team` to read existing docs pages).
 
 How to express that depends on the token source:
 
-- **GitHub App** (recommended for non-interactive deployments). In the App's settings, repository permissions → Contents: Read and write, Pull requests: Read and write; repository access → Only select repositories → `osinfra-io/pt-logos`, `osinfra-io/pt-corpus`, `osinfra-io/pt-pneuma`. (Read-only on corpus/pneuma is enough — the App-permissions UI does not let you set per-repo permission levels, so the same Read/Write set applies to all selected repos; if least privilege matters, use a separate App for the helpers renderers.) Mint installation tokens with [`actions/create-github-app-token`](https://github.com/actions/create-github-app-token) (already used elsewhere in the org) and pass the result as `GITHUB_TOKEN`.
-- **Fine-grained PAT** (local development). At <https://github.com/settings/personal-access-tokens>, resource owner `osinfra-io`; repository access → Only select repositories → `osinfra-io/pt-logos`, `osinfra-io/pt-corpus`, `osinfra-io/pt-pneuma`; repository permissions → Contents: Read and write, Pull requests: Read and write. (Same per-repo permission caveat as the App option above.)
-- **`gh auth token`** works for local development as long as your account can push to a branch on `pt-logos` and open PRs against it, and read `pt-corpus` and `pt-pneuma`. Prefer a fine-grained PAT or App token for anything non-interactive.
+- **GitHub App** (recommended for non-interactive deployments). In the App's settings, repository permissions → Contents: Read and write, Pull requests: Read and write; repository access → Only select repositories → `osinfra-io/pt-logos`, `osinfra-io/pt-corpus`, `osinfra-io/pt-pneuma`, `osinfra-io/pt-ekklesia-docs`. (Read-only on corpus/pneuma is enough — the App-permissions UI does not let you set per-repo permission levels, so the same Read/Write set applies to all selected repos; if least privilege matters, use a separate App for the helpers renderers.) Mint installation tokens with [`actions/create-github-app-token`](https://github.com/actions/create-github-app-token) (already used elsewhere in the org) and pass the result as `GITHUB_TOKEN`.
+- **Fine-grained PAT** (local development). At <https://github.com/settings/personal-access-tokens>, resource owner `osinfra-io`; repository access → Only select repositories → `osinfra-io/pt-logos`, `osinfra-io/pt-corpus`, `osinfra-io/pt-pneuma`, `osinfra-io/pt-ekklesia-docs`; repository permissions → Contents: Read and write, Pull requests: Read and write. (Same per-repo permission caveat as the App option above.)
+- **`gh auth token`** works for local development as long as your account can push to a branch on `pt-logos` and `pt-ekklesia-docs` and open PRs against them, and read `pt-corpus` and `pt-pneuma`. Prefer a fine-grained PAT or App token for anything non-interactive.
 - **Classic PAT** is not recommended — the closest equivalent (`repo` scope) grants far more than the tool needs.
 
 ### Operational errors
@@ -60,8 +68,9 @@ How to express that depends on the token source:
   |---|---|---|
   | `not_configured` | false | `GITHUB_TOKEN` was empty at startup. Set it and restart. |
   | `not_found` | false | `get_team` was called with an unknown `team_key`. |
-  | `invalid_input` | false | `lookup_user` was called with neither or both of `github_username` and `email`; or `render_corpus_helpers`/`render_pneuma_helpers` was called with a `team_key` that does not match the team-spec regex. |
-  | `source_parse_error` | false | A `teams/*.tfvars` in `pt-logos@main`, or `helpers.tofu` in `pt-corpus@main`/`pt-pneuma@main`, failed to parse, validate, or matched an unsupported shape (e.g. missing `module "core_helpers"` block, `logos_workspaces` not a list of plain strings). The source must be fixed; retrying will not help. |
+  | `invalid_input` | false | `lookup_user` was called with neither or both of `github_username` and `email`; or `render_corpus_helpers`/`render_pneuma_helpers` was called with a `team_key` that does not match the team-spec regex; or `render_sidebar_patch` was called without `current_sidebars_js`. |
+  | `docs_input_invalid` | false | `render_team_docs_index`, `render_sidebar_patch`, or `open_team_docs_pr` was given a spec the docs renderer can't use (missing `display_name_comment`, unknown `team_type`, `team_key` without a recognised prefix). |
+  | `source_parse_error` | false | A `teams/*.tfvars` in `pt-logos@main`, `helpers.tofu` in `pt-corpus@main`/`pt-pneuma@main`, or `sidebars.js` in `pt-ekklesia-docs` failed to parse, validate, or matched an unsupported shape (e.g. missing `module "core_helpers"` block, `logos_workspaces` not a list of plain strings, missing `// region:` / `// endregion:` anchors). The source must be fixed; retrying will not help. |
   | `branch_diverged` | false | The team branch has diverged from `main` and an open PR exists; the tool refuses to rewrite history under a human's PR. Rebase or close the PR, then retry. (write tools only) |
   | `github_conflict` | true | A 409/422 from GitHub raced our write and didn't auto-reconcile. Retry. (write tools only) |
   | `github_api_error` | true | Other GitHub API failure (network, 5xx, unexpected 4xx). Retry; if persistent, check the GitHub status page and the token's permissions. |

--- a/cmd/pt-techne-mcp-server/main.go
+++ b/cmd/pt-techne-mcp-server/main.go
@@ -7,12 +7,16 @@
 //   - open_team_pr            — open or update a PR on osinfra-io/pt-logos with the
 //     rendered tfvars (requires GITHUB_TOKEN)
 //   - list_teams              — summary index of every team in pt-logos@main (requires GITHUB_TOKEN)
-//   - get_team                — parsed spec for one team (requires GITHUB_TOKEN)
+//   - get_team                — parsed spec + docs_pages for one team (requires GITHUB_TOKEN)
 //   - lookup_user             — every team and role a user appears in (requires GITHUB_TOKEN)
 //   - find_repo               — which team owns a github repository (requires GITHUB_TOKEN)
 //   - render_corpus_helpers   — insert a team's main-production workspace into
 //     osinfra-io/pt-corpus/helpers.tofu (requires GITHUB_TOKEN)
 //   - render_pneuma_helpers   — same for osinfra-io/pt-pneuma/helpers.tofu (requires GITHUB_TOKEN)
+//   - render_team_docs_index  — render the team's docs/<section>/<team>/index.md page
+//   - render_sidebar_patch    — patch a supplied pt-ekklesia-docs sidebars.js
+//   - open_team_docs_pr       — open or update a PR on osinfra-io/pt-ekklesia-docs
+//     with the rendered docs index + sidebars patch (requires GITHUB_TOKEN)
 //
 // Transport is stdio only.
 package main
@@ -60,6 +64,9 @@ func main() {
 	tools.FindRepo(server, v, ghClient)
 	tools.RenderCorpusHelpers(server, ghClient)
 	tools.RenderPneumaHelpers(server, ghClient)
+	tools.RenderTeamDocsIndex(server, v)
+	tools.RenderSidebarPatch(server, v)
+	tools.OpenTeamDocsPR(server, v, ghClient)
 
 	if err := server.Run(ctx, &mcp.StdioTransport{}); err != nil {
 		log.Fatalf("server: %v", err)

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -21,7 +21,7 @@ Team display name. Title Case; spaces and the lowercase word "and" are allowed.
 
 ## `display_name_comment`
 
-Optional inline comment rendered after display_name. Used for the team etymology blurb.
+Optional inline comment rendered after display_name. Used for the team etymology blurb. Also used as the `description` frontmatter on the team's docs index page (rendered by render_team_docs_index); that tool requires this field.
 
 - **type:** `string`
 - **required:** false

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -21,7 +21,7 @@ Team display name. Title Case; spaces and the lowercase word "and" are allowed.
 
 ## `display_name_comment`
 
-Optional inline comment rendered after display_name. Used for the team etymology blurb. Also used as the `description` frontmatter on the team's docs index page (rendered by render_team_docs_index); that tool requires this field.
+Optional inline comment rendered after display_name. Used for the team etymology blurb. Also used as the `description` frontmatter on the team's docs index page (rendered by pt-techne-mcp-server/render_team_docs_index); that tool requires this field.
 
 - **type:** `string`
 - **required:** false

--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -192,12 +192,18 @@ func (c *goClient) ListDirInRepo(ctx context.Context, repo, path, ref string) ([
 }
 
 func (c *goClient) listDir(ctx context.Context, repo, path, ref string) ([]string, bool, error) {
-	_, dir, resp, err := c.api.Repositories.GetContents(ctx, Owner, repo, path, &gh.RepositoryContentGetOptions{Ref: ref})
+	file, dir, resp, err := c.api.Repositories.GetContents(ctx, Owner, repo, path, &gh.RepositoryContentGetOptions{Ref: ref})
 	if err != nil {
 		if resp != nil && resp.StatusCode == http.StatusNotFound {
 			return nil, false, nil
 		}
 		return nil, false, err
+	}
+	// A non-nil file means path resolved to a single file. Treating that
+	// as an empty directory would silently mask a misconfigured caller,
+	// so surface it as an error with full context.
+	if file != nil {
+		return nil, false, fmt.Errorf("%s/%s@%s is a file, not a directory", repo, path, ref)
 	}
 	out := make([]string, 0, len(dir))
 	for _, e := range dir {

--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -14,11 +14,22 @@ import (
 	"golang.org/x/oauth2"
 )
 
-// Repo is the hard-coded target. v0 deliberately has no repo parameter.
+// Repo is the hard-coded write target for tools that target pt-logos
+// (open_team_pr, the four read tools, etc). Tools that write to other
+// repos under the same org pass repo as a parameter via the *InRepo
+// methods below.
 const (
 	Owner = "osinfra-io"
 	Repo  = "pt-logos"
 	Base  = "main"
+)
+
+// Repos for cross-repo helpers; kept as named constants so callers do
+// not hard-code repository names at use sites.
+const (
+	RepoCorpus       = "pt-corpus"
+	RepoPneuma       = "pt-pneuma"
+	RepoEkklesiaDocs = "pt-ekklesia-docs"
 )
 
 // CompareStatus is the result of comparing a branch against the base.
@@ -53,9 +64,23 @@ type Client interface {
 	// GetFileInRepo reads a single file from a sibling repo under
 	// osinfra-io. Used by the helpers renderers (render_corpus_helpers,
 	// render_pneuma_helpers) which fetch helpers.tofu from pt-corpus and
-	// pt-pneuma respectively. Read-only; the write methods above remain
-	// pt-logos-only.
+	// pt-pneuma respectively, and by open_team_docs_pr / get_team's
+	// docs_pages probe against pt-ekklesia-docs.
 	GetFileInRepo(ctx context.Context, repo, path, ref string) (content []byte, blobSHA string, exists bool, err error)
+	// ListDirInRepo lists files in a directory of a sibling repo under
+	// osinfra-io. Used by get_team to enumerate a team's docs pages.
+	ListDirInRepo(ctx context.Context, repo, path, ref string) (names []string, exists bool, err error)
+	// Cross-repo write surface used by open_team_docs_pr (writes to
+	// pt-ekklesia-docs). Mirrors the pt-logos-only methods above so the
+	// same transaction shape works for any repo under osinfra-io.
+	GetRefInRepo(ctx context.Context, repo, branch string) (sha string, exists bool, err error)
+	CreateRefInRepo(ctx context.Context, repo, branch, fromSHA string) error
+	UpdateRefInRepo(ctx context.Context, repo, branch, toSHA string, force bool) error
+	DeleteRefInRepo(ctx context.Context, repo, branch string) error
+	CompareCommitsInRepo(ctx context.Context, repo, base, head string) (CompareStatus, error)
+	CreateOrUpdateFileInRepo(ctx context.Context, repo, path, branch, blobSHA string, content []byte, message string) (commitSHA string, err error)
+	ListOpenPRsInRepo(ctx context.Context, repo, head, base string) ([]PullRequest, error)
+	CreatePRInRepo(ctx context.Context, repo, head, base, title, body string) (PullRequest, error)
 	CreateOrUpdateFile(ctx context.Context, path, branch, blobSHA string, content []byte, message string) (commitSHA string, err error)
 	ListOpenPRs(ctx context.Context, head, base string) ([]PullRequest, error)
 	CreatePR(ctx context.Context, head, base, title, body string) (PullRequest, error)
@@ -159,7 +184,15 @@ func (c *goClient) GetFileInRepo(ctx context.Context, repo, path, ref string) ([
 }
 
 func (c *goClient) ListDir(ctx context.Context, path, ref string) ([]string, bool, error) {
-	_, dir, resp, err := c.api.Repositories.GetContents(ctx, Owner, Repo, path, &gh.RepositoryContentGetOptions{Ref: ref})
+	return c.listDir(ctx, Repo, path, ref)
+}
+
+func (c *goClient) ListDirInRepo(ctx context.Context, repo, path, ref string) ([]string, bool, error) {
+	return c.listDir(ctx, repo, path, ref)
+}
+
+func (c *goClient) listDir(ctx context.Context, repo, path, ref string) ([]string, bool, error) {
+	_, dir, resp, err := c.api.Repositories.GetContents(ctx, Owner, repo, path, &gh.RepositoryContentGetOptions{Ref: ref})
 	if err != nil {
 		if resp != nil && resp.StatusCode == http.StatusNotFound {
 			return nil, false, nil
@@ -174,6 +207,108 @@ func (c *goClient) ListDir(ctx context.Context, path, ref string) ([]string, boo
 	}
 	sort.Strings(out)
 	return out, true, nil
+}
+
+// Cross-repo write methods. These mirror the pt-logos-only methods
+// above but accept an explicit repo so open_team_docs_pr can target
+// pt-ekklesia-docs. Both sets share the same goClient receiver.
+
+func (c *goClient) GetRefInRepo(ctx context.Context, repo, branch string) (string, bool, error) {
+	ref, resp, err := c.api.Git.GetRef(ctx, Owner, repo, "refs/heads/"+branch)
+	if err != nil {
+		if resp != nil && resp.StatusCode == http.StatusNotFound {
+			return "", false, nil
+		}
+		return "", false, err
+	}
+	return ref.GetObject().GetSHA(), true, nil
+}
+
+func (c *goClient) CreateRefInRepo(ctx context.Context, repo, branch, fromSHA string) error {
+	full := "refs/heads/" + branch
+	_, _, err := c.api.Git.CreateRef(ctx, Owner, repo, &gh.Reference{
+		Ref:    &full,
+		Object: &gh.GitObject{SHA: &fromSHA},
+	})
+	return err
+}
+
+func (c *goClient) UpdateRefInRepo(ctx context.Context, repo, branch, toSHA string, force bool) error {
+	full := "refs/heads/" + branch
+	_, _, err := c.api.Git.UpdateRef(ctx, Owner, repo, &gh.Reference{
+		Ref:    &full,
+		Object: &gh.GitObject{SHA: &toSHA},
+	}, force)
+	return err
+}
+
+func (c *goClient) DeleteRefInRepo(ctx context.Context, repo, branch string) error {
+	_, err := c.api.Git.DeleteRef(ctx, Owner, repo, "refs/heads/"+branch)
+	return err
+}
+
+func (c *goClient) CompareCommitsInRepo(ctx context.Context, repo, base, head string) (CompareStatus, error) {
+	cmp, _, err := c.api.Repositories.CompareCommits(ctx, Owner, repo, base, head, nil)
+	if err != nil {
+		return "", err
+	}
+	switch cmp.GetStatus() {
+	case "identical":
+		return StatusIdentical, nil
+	case "ahead":
+		return StatusAhead, nil
+	case "behind":
+		return StatusBehind, nil
+	case "diverged":
+		return StatusDiverged, nil
+	default:
+		return "", errors.New("unknown compare status: " + cmp.GetStatus())
+	}
+}
+
+func (c *goClient) CreateOrUpdateFileInRepo(ctx context.Context, repo, path, branch, blobSHA string, content []byte, message string) (string, error) {
+	opts := &gh.RepositoryContentFileOptions{
+		Branch:  &branch,
+		Content: content,
+		Message: &message,
+	}
+	if blobSHA != "" {
+		opts.SHA = &blobSHA
+	}
+	res, _, err := c.api.Repositories.UpdateFile(ctx, Owner, repo, path, opts)
+	if err != nil {
+		return "", err
+	}
+	return res.GetSHA(), nil
+}
+
+func (c *goClient) ListOpenPRsInRepo(ctx context.Context, repo, head, base string) ([]PullRequest, error) {
+	prs, _, err := c.api.PullRequests.List(ctx, Owner, repo, &gh.PullRequestListOptions{
+		State: "open",
+		Head:  Owner + ":" + head,
+		Base:  base,
+	})
+	if err != nil {
+		return nil, err
+	}
+	out := make([]PullRequest, 0, len(prs))
+	for _, p := range prs {
+		out = append(out, PullRequest{Number: p.GetNumber(), URL: p.GetHTMLURL()})
+	}
+	return out, nil
+}
+
+func (c *goClient) CreatePRInRepo(ctx context.Context, repo, head, base, title, body string) (PullRequest, error) {
+	pr, _, err := c.api.PullRequests.Create(ctx, Owner, repo, &gh.NewPullRequest{
+		Title: &title,
+		Head:  &head,
+		Base:  &base,
+		Body:  &body,
+	})
+	if err != nil {
+		return PullRequest{}, err
+	}
+	return PullRequest{Number: pr.GetNumber(), URL: pr.GetHTMLURL()}, nil
 }
 
 func (c *goClient) CreateOrUpdateFile(ctx context.Context, path, branch, blobSHA string, content []byte, message string) (string, error) {

--- a/internal/render/docs/render.go
+++ b/internal/render/docs/render.go
@@ -1,0 +1,109 @@
+// Package docs renders a deterministic team-index Markdown page for the
+// pt-ekklesia-docs Docusaurus site.
+//
+// Output is the minimum stub humans extend with Bounded Context,
+// Ubiquitous Language, ADRs, and so on. The renderer never overwrites
+// hand-authored content — open_team_docs_pr is only meant to land the
+// initial page; subsequent edits stay human-driven.
+//
+// Frontmatter is fixed at sidebar_label and description. Body is a
+// heading, the description as a lede paragraph, and a placeholder
+// Repositories section.
+package docs
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+
+	"github.com/osinfra-io/pt-techne-mcp-server/internal/spec"
+)
+
+// Result is the rendered page plus its repo-relative path.
+type Result struct {
+	Path    string
+	Content []byte
+}
+
+// Render produces the team's docs index page. The path is derived from
+// team_type (section folder) and team_key (team folder).
+//
+// Returns an error rather than producing a degenerate page when:
+//
+//   - team is nil, team_key, display_name, or team_type is empty
+//   - display_name_comment is empty (used as the frontmatter description
+//     and the lede paragraph; without it the page is meaningless)
+//   - team_type is not one of the four known Team Topologies values
+func Render(t *spec.Team) (*Result, error) {
+	if t == nil {
+		return nil, fmt.Errorf("render: team is required")
+	}
+	if t.TeamKey == "" {
+		return nil, fmt.Errorf("render: team_key is required")
+	}
+	if t.DisplayName == "" {
+		return nil, fmt.Errorf("render: display_name is required")
+	}
+	if t.DisplayNameComment == "" {
+		return nil, fmt.Errorf("render: display_name_comment is required (used as the docs page description)")
+	}
+	section, err := SectionFor(t.TeamType)
+	if err != nil {
+		return nil, err
+	}
+	folder, err := TeamFolder(t.TeamKey)
+	if err != nil {
+		return nil, err
+	}
+
+	var b bytes.Buffer
+	b.WriteString("---\n")
+	b.WriteString("sidebar_label: ")
+	b.WriteString(t.DisplayName)
+	b.WriteString("\n")
+	b.WriteString("description: ")
+	b.WriteString(t.DisplayNameComment)
+	b.WriteString("\n")
+	b.WriteString("---\n\n")
+	b.WriteString("# ")
+	b.WriteString(t.DisplayName)
+	b.WriteString("\n\n")
+	b.WriteString(t.DisplayNameComment)
+	b.WriteString("\n\n")
+	b.WriteString("## Repositories\n\n")
+	b.WriteString("<!-- Maintained by humans. List the team's repositories here. -->\n")
+
+	return &Result{
+		Path:    "docs/" + section + "/" + folder + "/index.md",
+		Content: b.Bytes(),
+	}, nil
+}
+
+// SectionFor maps a Team Topologies team_type to the Docusaurus section
+// folder used by pt-ekklesia-docs.
+func SectionFor(teamType string) (string, error) {
+	switch teamType {
+	case "platform-team":
+		return "platform-teams", nil
+	case "stream-aligned-team":
+		return "stream-aligned-teams", nil
+	case "complicated-subsystem-team":
+		return "complicated-subsystem-teams", nil
+	case "enabling-team":
+		return "enabling-teams", nil
+	default:
+		return "", fmt.Errorf("render: unknown team_type %q", teamType)
+	}
+}
+
+// TeamFolder strips the team_type prefix (pt-/st-/ct-/et-) from team_key
+// to derive the docs folder name. Matches the existing pt-ekklesia-docs
+// layout where every team folder is the bare name (e.g. pt-logos -> logos).
+func TeamFolder(teamKey string) (string, error) {
+	for _, p := range []string{"pt-", "st-", "ct-", "et-"} {
+		if strings.HasPrefix(teamKey, p) {
+			return strings.TrimPrefix(teamKey, p), nil
+		}
+	}
+	return "", fmt.Errorf("render: team_key %q does not start with pt-/st-/ct-/et-", teamKey)
+}

--- a/internal/render/docs/render_test.go
+++ b/internal/render/docs/render_test.go
@@ -1,0 +1,129 @@
+package docs
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/osinfra-io/pt-techne-mcp-server/internal/spec"
+)
+
+// TestRenderGoldens drives the renderer against every input fixture and
+// asserts the output matches a golden Markdown file byte-for-byte. Set
+// RENDER_UPDATE=1 to rewrite goldens.
+func TestRenderGoldens(t *testing.T) {
+	updateGoldens := os.Getenv("RENDER_UPDATE") == "1"
+	entries, err := os.ReadDir("testdata/input")
+	if err != nil {
+		t.Fatalf("read input dir: %v", err)
+	}
+	for _, e := range entries {
+		if e.IsDir() || filepath.Ext(e.Name()) != ".json" {
+			continue
+		}
+		name := e.Name()
+		t.Run(name, func(t *testing.T) {
+			data, err := os.ReadFile(filepath.Join("testdata/input", name))
+			if err != nil {
+				t.Fatalf("read input: %v", err)
+			}
+			var team spec.Team
+			if err := json.Unmarshal(data, &team); err != nil {
+				t.Fatalf("decode input: %v", err)
+			}
+			res, err := Render(&team)
+			if err != nil {
+				t.Fatalf("render: %v", err)
+			}
+			goldenPath := filepath.Join("testdata/golden", name[:len(name)-len(".json")]+".md")
+			if updateGoldens {
+				if err := os.WriteFile(goldenPath, res.Content, 0o644); err != nil {
+					t.Fatalf("write golden: %v", err)
+				}
+				return
+			}
+			want, err := os.ReadFile(goldenPath)
+			if err != nil {
+				t.Fatalf("read golden: %v (re-run with RENDER_UPDATE=1 to create)", err)
+			}
+			if string(res.Content) != string(want) {
+				t.Errorf("render mismatch for %s\n--- got ---\n%s\n--- want ---\n%s", name, res.Content, want)
+			}
+		})
+	}
+}
+
+func TestRenderPathDerivation(t *testing.T) {
+	cases := []struct {
+		teamKey, teamType, wantPath string
+	}{
+		{"pt-logos", "platform-team", "docs/platform-teams/logos/index.md"},
+		{"st-ethos", "stream-aligned-team", "docs/stream-aligned-teams/ethos/index.md"},
+		{"ct-mysterion", "complicated-subsystem-team", "docs/complicated-subsystem-teams/mysterion/index.md"},
+		{"et-soteria", "enabling-team", "docs/enabling-teams/soteria/index.md"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.teamKey, func(t *testing.T) {
+			res, err := Render(&spec.Team{
+				TeamKey:            tc.teamKey,
+				TeamType:           tc.teamType,
+				DisplayName:        "Test",
+				DisplayNameComment: "Test description.",
+			})
+			if err != nil {
+				t.Fatalf("render: %v", err)
+			}
+			if res.Path != tc.wantPath {
+				t.Errorf("path: got %q want %q", res.Path, tc.wantPath)
+			}
+		})
+	}
+}
+
+func TestRenderRequiredFields(t *testing.T) {
+	base := spec.Team{
+		TeamKey:            "pt-test",
+		TeamType:           "platform-team",
+		DisplayName:        "Test",
+		DisplayNameComment: "Test description.",
+	}
+	cases := []struct {
+		name string
+		mut  func(*spec.Team)
+		want string
+	}{
+		{"nil team", nil, "team is required"},
+		{"empty team_key", func(t *spec.Team) { t.TeamKey = "" }, "team_key is required"},
+		{"empty display_name", func(t *spec.Team) { t.DisplayName = "" }, "display_name is required"},
+		{"empty display_name_comment", func(t *spec.Team) { t.DisplayNameComment = "" }, "display_name_comment is required"},
+		{"unknown team_type", func(t *spec.Team) { t.TeamType = "unknown" }, "unknown team_type"},
+		{"bad team_key prefix", func(t *spec.Team) { t.TeamKey = "xx-foo" }, "does not start with"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var in *spec.Team
+			if tc.mut != nil {
+				cp := base
+				in = &cp
+				tc.mut(in)
+			}
+			_, err := Render(in)
+			if err == nil {
+				t.Fatalf("expected error containing %q, got nil", tc.want)
+			}
+			if !contains(err.Error(), tc.want) {
+				t.Errorf("error = %q, want containing %q", err.Error(), tc.want)
+			}
+		})
+	}
+}
+
+func contains(s, sub string) bool {
+	for i := 0; i+len(sub) <= len(s); i++ {
+		if s[i:i+len(sub)] == sub {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/render/docs/render_test.go
+++ b/internal/render/docs/render_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/osinfra-io/pt-techne-mcp-server/internal/spec"
@@ -112,18 +113,9 @@ func TestRenderRequiredFields(t *testing.T) {
 			if err == nil {
 				t.Fatalf("expected error containing %q, got nil", tc.want)
 			}
-			if !contains(err.Error(), tc.want) {
+			if !strings.Contains(err.Error(), tc.want) {
 				t.Errorf("error = %q, want containing %q", err.Error(), tc.want)
 			}
 		})
 	}
-}
-
-func contains(s, sub string) bool {
-	for i := 0; i+len(sub) <= len(s); i++ {
-		if s[i:i+len(sub)] == sub {
-			return true
-		}
-	}
-	return false
 }

--- a/internal/render/docs/testdata/golden/pt-foo.md
+++ b/internal/render/docs/testdata/golden/pt-foo.md
@@ -1,0 +1,12 @@
+---
+sidebar_label: Foo
+description: The example platform team that does foo. Used as a renderer fixture; not a real team.
+---
+
+# Foo
+
+The example platform team that does foo. Used as a renderer fixture; not a real team.
+
+## Repositories
+
+<!-- Maintained by humans. List the team's repositories here. -->

--- a/internal/render/docs/testdata/golden/st-bar.md
+++ b/internal/render/docs/testdata/golden/st-bar.md
@@ -1,0 +1,12 @@
+---
+sidebar_label: Bar
+description: The example stream-aligned team that delivers bar.
+---
+
+# Bar
+
+The example stream-aligned team that delivers bar.
+
+## Repositories
+
+<!-- Maintained by humans. List the team's repositories here. -->

--- a/internal/render/docs/testdata/input/pt-foo.json
+++ b/internal/render/docs/testdata/input/pt-foo.json
@@ -1,0 +1,6 @@
+{
+  "team_key": "pt-foo",
+  "team_type": "platform-team",
+  "display_name": "Foo",
+  "display_name_comment": "The example platform team that does foo. Used as a renderer fixture; not a real team."
+}

--- a/internal/render/docs/testdata/input/st-bar.json
+++ b/internal/render/docs/testdata/input/st-bar.json
@@ -1,0 +1,6 @@
+{
+  "team_key": "st-bar",
+  "team_type": "stream-aligned-team",
+  "display_name": "Bar",
+  "display_name_comment": "The example stream-aligned team that delivers bar."
+}

--- a/internal/render/sidebar/render.go
+++ b/internal/render/sidebar/render.go
@@ -83,8 +83,10 @@ func Render(existing []byte, section, teamFolder string) ([]byte, error) {
 	}
 
 	line := indent + "'" + id + "',\n"
-	out := make([]byte, 0, len(existing)+len(line))
-	out = append(out, existing[:endLineStart]...)
+	// Build via append rather than make([]byte, 0, len(existing)+len(line)):
+	// the explicit capacity computation tripped a CodeQL overflow heuristic
+	// even though the input is bounded by maxSidebarBytes above.
+	out := append([]byte(nil), existing[:endLineStart]...)
 	out = append(out, []byte(line)...)
 	out = append(out, existing[endLineStart:]...)
 	return out, nil

--- a/internal/render/sidebar/render.go
+++ b/internal/render/sidebar/render.go
@@ -144,11 +144,16 @@ func regionContainsID(region []byte, id string) bool {
 // anchor pair; otherwise returns the first ErrAnchorsMissing.
 func EnsureAnchors(src []byte, sections ...string) error {
 	for _, s := range sections {
-		if _, err := findRegionStart(src, s); err != nil {
+		regionStart, err := findRegionStart(src, s)
+		if err != nil {
 			return err
 		}
-		if _, _, err := findEndregion(src, s); err != nil {
+		endLineStart, _, err := findEndregion(src, s)
+		if err != nil {
 			return err
+		}
+		if endLineStart < regionStart {
+			return &ErrAnchorsMissing{Section: s}
 		}
 	}
 	return nil

--- a/internal/render/sidebar/render.go
+++ b/internal/render/sidebar/render.go
@@ -37,6 +37,11 @@ func (e *ErrAnchorsMissing) Error() string {
 	return fmt.Sprintf("sidebars.js: missing or malformed // region: %s / // endregion: %s anchor pair", e.Section, e.Section)
 }
 
+// maxSidebarBytes bounds the input size accepted by Render. Real
+// sidebars.js files are <100 KiB; this cap exists purely to make the
+// allocation in Render obviously unable to overflow.
+const maxSidebarBytes = 10 << 20 // 10 MiB
+
 // Render appends a plain `'<section>/<team_folder>/index'` entry to the
 // region for section. If the entry is already present (in any form —
 // either as a plain string or as a category referencing the same id),
@@ -51,6 +56,9 @@ func Render(existing []byte, section, teamFolder string) ([]byte, error) {
 	}
 	if teamFolder == "" {
 		return nil, fmt.Errorf("sidebar: team_folder is required")
+	}
+	if len(existing) > maxSidebarBytes {
+		return nil, fmt.Errorf("sidebar: input is %d bytes, exceeds %d byte cap", len(existing), maxSidebarBytes)
 	}
 
 	regionStart, err := findRegionStart(existing, section)

--- a/internal/render/sidebar/render.go
+++ b/internal/render/sidebar/render.go
@@ -1,0 +1,139 @@
+// Package sidebar inserts a team's docs index entry into the
+// pt-ekklesia-docs sidebars.js file by locating // region:<section>
+// markers and appending a single line just before the matching
+// // endregion: marker.
+//
+// The renderer is intentionally text-based — sidebars.js is real JS, not
+// data — and relies on the // region: <section> / // endregion: <section>
+// anchor convention added by the prep PR. Missing anchors return a
+// structured error instead of any silent fallback.
+//
+// Design notes:
+//
+//   - Existing entries are never reordered. The visible order in
+//     sidebars.js conveys meaning (the platform team list is roughly the
+//     dependency order Logos → Corpus → Pneuma → Arche → ...), and
+//     alphabetising would silently rewrite it. The renderer therefore
+//     appends new entries at the bottom of the region. Humans reorder
+//     manually when they care about position.
+//   - Output is byte-stable on noop: when the entry is already present
+//     between the markers (in any form — plain string or category whose
+//     link.id matches), the input bytes are returned unchanged.
+package sidebar
+
+import (
+	"fmt"
+	"regexp"
+)
+
+// ErrAnchorsMissing is returned when the // region: / // endregion:
+// markers for a section are absent or malformed. Callers should surface
+// this as source_parse_error.
+type ErrAnchorsMissing struct {
+	Section string
+}
+
+func (e *ErrAnchorsMissing) Error() string {
+	return fmt.Sprintf("sidebars.js: missing or malformed // region: %s / // endregion: %s anchor pair", e.Section, e.Section)
+}
+
+// Render appends a plain `'<section>/<team_folder>/index'` entry to the
+// region for section. If the entry is already present (in any form —
+// either as a plain string or as a category referencing the same id),
+// the input bytes are returned unchanged.
+//
+// section is the Docusaurus section folder (e.g. "platform-teams") and
+// teamFolder is the team's folder name within that section (e.g. "logos").
+// Both must be non-empty.
+func Render(existing []byte, section, teamFolder string) ([]byte, error) {
+	if section == "" {
+		return nil, fmt.Errorf("sidebar: section is required")
+	}
+	if teamFolder == "" {
+		return nil, fmt.Errorf("sidebar: team_folder is required")
+	}
+
+	regionStart, err := findRegionStart(existing, section)
+	if err != nil {
+		return nil, err
+	}
+	endLineStart, indent, err := findEndregion(existing, section)
+	if err != nil {
+		return nil, err
+	}
+
+	id := section + "/" + teamFolder + "/index"
+	region := existing[regionStart:endLineStart]
+	if regionContainsID(region, id) {
+		return existing, nil
+	}
+
+	line := indent + "'" + id + "',\n"
+	out := make([]byte, 0, len(existing)+len(line))
+	out = append(out, existing[:endLineStart]...)
+	out = append(out, []byte(line)...)
+	out = append(out, existing[endLineStart:]...)
+	return out, nil
+}
+
+// findRegionStart returns the byte offset immediately after the
+// // region: <section> marker line.
+func findRegionStart(src []byte, section string) (int, error) {
+	re := regexp.MustCompile(`(?m)^[ \t]*// region: ` + regexp.QuoteMeta(section) + `[ \t]*\r?\n`)
+	m := re.FindIndex(src)
+	if m == nil {
+		return 0, &ErrAnchorsMissing{Section: section}
+	}
+	return m[1], nil
+}
+
+// findEndregion returns the byte offset at the start of the
+// // endregion: <section> marker line plus the indentation string used
+// on that line. Insertions go at this offset so the new entry lands
+// just before the marker, with matching indentation.
+func findEndregion(src []byte, section string) (int, string, error) {
+	re := regexp.MustCompile(`(?m)^([ \t]*)// endregion: ` + regexp.QuoteMeta(section) + `[ \t]*\r?\n`)
+	m := re.FindSubmatchIndex(src)
+	if m == nil {
+		return 0, "", &ErrAnchorsMissing{Section: section}
+	}
+	return m[0], string(src[m[2]:m[3]]), nil
+}
+
+var (
+	plainEntryRe = regexp.MustCompile(`(?m)^[ \t]*'([^']+)',?\s*$`)
+	categoryIDRe = regexp.MustCompile(`id:\s*'([^']+)'`)
+)
+
+// regionContainsID reports whether the given region bytes already
+// reference id, either as a plain string entry or inside a category's
+// link.id.
+func regionContainsID(region []byte, id string) bool {
+	for _, m := range plainEntryRe.FindAllSubmatch(region, -1) {
+		if string(m[1]) == id {
+			return true
+		}
+	}
+	for _, m := range categoryIDRe.FindAllSubmatch(region, -1) {
+		if string(m[1]) == id {
+			return true
+		}
+	}
+	return false
+}
+
+// EnsureAnchors is a defensive helper a caller can use to verify a
+// sidebars.js source has all expected section anchors before attempting
+// any edit. Returns nil when every section in sections has a matching
+// anchor pair; otherwise returns the first ErrAnchorsMissing.
+func EnsureAnchors(src []byte, sections ...string) error {
+	for _, s := range sections {
+		if _, err := findRegionStart(src, s); err != nil {
+			return err
+		}
+		if _, _, err := findEndregion(src, s); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/internal/render/sidebar/render.go
+++ b/internal/render/sidebar/render.go
@@ -144,6 +144,9 @@ func regionContainsID(region []byte, id string) bool {
 // anchor pair; otherwise returns the first ErrAnchorsMissing.
 func EnsureAnchors(src []byte, sections ...string) error {
 	for _, s := range sections {
+		if s == "" {
+			return fmt.Errorf("sidebar: section is required")
+		}
 		regionStart, err := findRegionStart(src, s)
 		if err != nil {
 			return err

--- a/internal/render/sidebar/render.go
+++ b/internal/render/sidebar/render.go
@@ -61,6 +61,12 @@ func Render(existing []byte, section, teamFolder string) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
+	// A misordered anchor pair (endregion before region) would otherwise
+	// panic on the slice below. Surface it as the same structured error
+	// callers already handle for missing anchors.
+	if endLineStart < regionStart {
+		return nil, &ErrAnchorsMissing{Section: section}
+	}
 
 	id := section + "/" + teamFolder + "/index"
 	region := existing[regionStart:endLineStart]

--- a/internal/render/sidebar/render_test.go
+++ b/internal/render/sidebar/render_test.go
@@ -99,6 +99,25 @@ func TestRenderNoopWhenCategoryAlreadyReferencesID(t *testing.T) {
 	}
 }
 
+func TestRenderMisorderedAnchors(t *testing.T) {
+	// endregion appears before region — must surface ErrAnchorsMissing
+	// instead of panicking on the slice.
+	src := []byte(`// @ts-check
+const sidebars = { docs: [{ items: [
+  // endregion: platform-teams
+  // region: platform-teams
+] }] };
+`)
+	_, err := Render(src, "platform-teams", "foo")
+	if err == nil {
+		t.Fatalf("expected ErrAnchorsMissing, got nil")
+	}
+	var anchorsErr *ErrAnchorsMissing
+	if !errAs(err, &anchorsErr) {
+		t.Errorf("error type: got %T, want *ErrAnchorsMissing", err)
+	}
+}
+
 func TestRenderMissingAnchors(t *testing.T) {
 	src := []byte(`// @ts-check
 const sidebars = { docs: [{ items: [] }] };

--- a/internal/render/sidebar/render_test.go
+++ b/internal/render/sidebar/render_test.go
@@ -145,6 +145,9 @@ func TestEnsureAnchors(t *testing.T) {
 	if err := EnsureAnchors([]byte(fixture), "platform-teams", "stream-aligned-teams"); err != nil {
 		t.Errorf("expected nil error, got %v", err)
 	}
+	if err := EnsureAnchors([]byte(fixture), ""); err == nil {
+		t.Errorf("expected error for empty section name")
+	}
 	if err := EnsureAnchors([]byte(fixture), "missing-section"); err == nil {
 		t.Errorf("expected ErrAnchorsMissing for absent section")
 	}

--- a/internal/render/sidebar/render_test.go
+++ b/internal/render/sidebar/render_test.go
@@ -148,6 +148,20 @@ func TestEnsureAnchors(t *testing.T) {
 	if err := EnsureAnchors([]byte(fixture), "missing-section"); err == nil {
 		t.Errorf("expected ErrAnchorsMissing for absent section")
 	}
+	misordered := []byte(`// @ts-check
+const sidebars = { docs: [{ items: [
+  // endregion: platform-teams
+  // region: platform-teams
+] }] };
+`)
+	err := EnsureAnchors(misordered, "platform-teams")
+	if err == nil {
+		t.Fatalf("expected ErrAnchorsMissing for misordered anchors, got nil")
+	}
+	var anchorsErr *ErrAnchorsMissing
+	if !errAs(err, &anchorsErr) {
+		t.Errorf("misordered anchors: error type = %T, want *ErrAnchorsMissing", err)
+	}
 }
 
 // errAs is a tiny errors.As shim to keep the test file's imports tight.

--- a/internal/render/sidebar/render_test.go
+++ b/internal/render/sidebar/render_test.go
@@ -1,0 +1,163 @@
+package sidebar
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+const fixture = `// @ts-check
+
+const sidebars = {
+  docs: [
+    {
+      type: 'category',
+      label: 'Platform Teams',
+      items: [
+        // region: platform-teams
+        {
+          type: 'category',
+          label: 'Logos',
+          link: { type: 'doc', id: 'platform-teams/logos/index' },
+          items: [
+            'platform-teams/logos/resource-hierarchy',
+          ],
+        },
+        // endregion: platform-teams
+      ],
+    },
+    {
+      type: 'category',
+      label: 'Stream-Aligned Teams',
+      items: [
+        // region: stream-aligned-teams
+        // endregion: stream-aligned-teams
+      ],
+    },
+  ],
+};
+
+export default sidebars;
+`
+
+func TestRenderInsertIntoEmptyRegion(t *testing.T) {
+	got, err := Render([]byte(fixture), "stream-aligned-teams", "ethos")
+	if err != nil {
+		t.Fatalf("render: %v", err)
+	}
+	if !strings.Contains(string(got), "'stream-aligned-teams/ethos/index',\n") {
+		t.Fatalf("expected new entry; got:\n%s", got)
+	}
+	// New line must sit just before the endregion marker, indented to match.
+	want := "        'stream-aligned-teams/ethos/index',\n        // endregion: stream-aligned-teams"
+	if !strings.Contains(string(got), want) {
+		t.Errorf("entry not placed before endregion with matching indent; got:\n%s", got)
+	}
+}
+
+func TestRenderInsertIntoPopulatedRegion(t *testing.T) {
+	got, err := Render([]byte(fixture), "platform-teams", "corpus")
+	if err != nil {
+		t.Fatalf("render: %v", err)
+	}
+	// Existing Logos entry must be unchanged and untouched.
+	if !strings.Contains(string(got), "label: 'Logos',\n") {
+		t.Errorf("existing Logos entry was disturbed; got:\n%s", got)
+	}
+	if !strings.Contains(string(got), "        'platform-teams/corpus/index',\n        // endregion: platform-teams") {
+		t.Errorf("new entry not placed at end of region; got:\n%s", got)
+	}
+}
+
+func TestRenderNoopWhenPlainEntryAlreadyPresent(t *testing.T) {
+	src := []byte(`// @ts-check
+const sidebars = {
+  docs: [{ items: [
+    // region: platform-teams
+    'platform-teams/logos/index',
+    // endregion: platform-teams
+  ]}],
+};
+`)
+	got, err := Render(src, "platform-teams", "logos")
+	if err != nil {
+		t.Fatalf("render: %v", err)
+	}
+	if string(got) != string(src) {
+		t.Errorf("noop expected; got:\n%s\nwant:\n%s", got, src)
+	}
+}
+
+func TestRenderNoopWhenCategoryAlreadyReferencesID(t *testing.T) {
+	got, err := Render([]byte(fixture), "platform-teams", "logos")
+	if err != nil {
+		t.Fatalf("render: %v", err)
+	}
+	if string(got) != fixture {
+		t.Errorf("noop expected when category already references id; output diverged")
+	}
+}
+
+func TestRenderMissingAnchors(t *testing.T) {
+	src := []byte(`// @ts-check
+const sidebars = { docs: [{ items: [] }] };
+`)
+	_, err := Render(src, "platform-teams", "foo")
+	if err == nil {
+		t.Fatalf("expected ErrAnchorsMissing, got nil")
+	}
+	var anchorsErr *ErrAnchorsMissing
+	if !errAs(err, &anchorsErr) {
+		t.Errorf("error type: got %T, want *ErrAnchorsMissing", err)
+	}
+}
+
+func TestRenderInputValidation(t *testing.T) {
+	if _, err := Render([]byte(fixture), "", "foo"); err == nil {
+		t.Errorf("empty section should fail")
+	}
+	if _, err := Render([]byte(fixture), "platform-teams", ""); err == nil {
+		t.Errorf("empty teamFolder should fail")
+	}
+}
+
+func TestEnsureAnchors(t *testing.T) {
+	if err := EnsureAnchors([]byte(fixture), "platform-teams", "stream-aligned-teams"); err != nil {
+		t.Errorf("expected nil error, got %v", err)
+	}
+	if err := EnsureAnchors([]byte(fixture), "missing-section"); err == nil {
+		t.Errorf("expected ErrAnchorsMissing for absent section")
+	}
+}
+
+// errAs is a tiny errors.As shim to keep the test file's imports tight.
+func errAs(err error, target **ErrAnchorsMissing) bool {
+	if e, ok := err.(*ErrAnchorsMissing); ok {
+		*target = e
+		return true
+	}
+	return false
+}
+
+// TestRenderAgainstRealFixture exercises the real pt-ekklesia-docs
+// sidebars.js (post anchor-comment prep PR) to catch any drift between
+// the renderer and the file shape it must edit.
+func TestRenderAgainstRealFixture(t *testing.T) {
+	path := filepath.Join("testdata", "sidebars.js")
+	src, err := os.ReadFile(path)
+	if err != nil {
+		t.Skipf("real fixture missing at %s: %v", path, err)
+	}
+	for _, section := range []string{"platform-teams", "stream-aligned-teams", "complicated-subsystem-teams", "enabling-teams"} {
+		out, err := Render(src, section, "newteam")
+		if err != nil {
+			t.Errorf("render %s: %v", section, err)
+			continue
+		}
+		want := "'" + section + "/newteam/index',"
+		if !strings.Contains(string(out), want) {
+			t.Errorf("section %s: expected %q in output", section, want)
+		}
+	}
+}

--- a/internal/render/sidebar/testdata/sidebars.js
+++ b/internal/render/sidebar/testdata/sidebars.js
@@ -1,0 +1,144 @@
+// @ts-check
+
+// The `// region: <section>` / `// endregion: <section>` markers below are
+// consumed by `pt-techne-mcp-server`'s `render_sidebar_patch` tool, which
+// inserts new team entries between them. Keep them in place; deleting or
+// renaming a marker will cause that tool to fail with `source_parse_error`.
+
+/** @type {import('@docusaurus/plugin-content-docs').SidebarsConfig} */
+const sidebars = {
+  docs: [
+    {
+      type: 'category',
+      label: 'Platform Teams',
+      link: { type: 'doc', id: 'platform-teams/index' },
+      items: [
+        // region: platform-teams
+        {
+          type: 'category',
+          label: 'Logos',
+          link: { type: 'doc', id: 'platform-teams/logos/index' },
+          items: [
+            'platform-teams/logos/resource-hierarchy',
+            'platform-teams/logos/identity-access',
+            'platform-teams/logos/team-topology',
+            'platform-teams/logos/saas-governance',
+          ],
+        },
+        {
+          type: 'category',
+          label: 'Corpus',
+          link: { type: 'doc', id: 'platform-teams/corpus/index' },
+          items: [
+            'platform-teams/corpus/tenancy',
+            'platform-teams/corpus/networking',
+            'platform-teams/corpus/data-services',
+            'platform-teams/corpus/ci-cd-enablement',
+          ],
+        },
+        {
+          type: 'category',
+          label: 'Pneuma',
+          link: { type: 'doc', id: 'platform-teams/pneuma/index' },
+          items: [
+            'platform-teams/pneuma/cluster-management',
+            'platform-teams/pneuma/service-mesh',
+            'platform-teams/pneuma/certificate-management',
+            'platform-teams/pneuma/policy-enforcement',
+            'platform-teams/pneuma/observability',
+          ],
+        },
+        {
+          type: 'category',
+          label: 'Arche',
+          link: { type: 'doc', id: 'platform-teams/arche/index' },
+          items: [
+            'platform-teams/arche/core-helpers',
+            'platform-teams/arche/module-development',
+            'platform-teams/arche/google-cloud',
+            'platform-teams/arche/kubernetes',
+          ],
+        },
+        {
+          type: 'category',
+          label: 'Ekklesia',
+          link: { type: 'doc', id: 'platform-teams/ekklesia/index' },
+          items: [
+            'platform-teams/ekklesia/documentation',
+          ],
+        },
+        {
+          type: 'category',
+          label: 'Kryptos',
+          link: { type: 'doc', id: 'platform-teams/kryptos/index' },
+          items: [
+            'platform-teams/kryptos/open-bao',
+          ],
+        },
+        {
+          type: 'category',
+          label: 'Techne',
+          link: { type: 'doc', id: 'platform-teams/techne/index' },
+          items: [
+            'platform-teams/techne/deployment-automation',
+            'platform-teams/techne/developer-experience',
+          ],
+        },
+        // endregion: platform-teams
+      ],
+    },
+    {
+      type: 'category',
+      label: 'Stream-Aligned Teams',
+      link: { type: 'doc', id: 'stream-aligned-teams/index' },
+      items: [
+        // region: stream-aligned-teams
+        {
+          type: 'category',
+          label: 'Ethos',
+          link: { type: 'doc', id: 'stream-aligned-teams/ethos/index' },
+          items: [],
+        },
+        // endregion: stream-aligned-teams
+      ],
+    },
+    {
+      type: 'category',
+      label: 'Complicated Subsystem Teams',
+      link: { type: 'doc', id: 'complicated-subsystem-teams/index' },
+      items: [
+        // region: complicated-subsystem-teams
+        {
+          type: 'category',
+          label: 'Mysterion',
+          link: { type: 'doc', id: 'complicated-subsystem-teams/mysterion/index' },
+          items: [],
+        },
+        // endregion: complicated-subsystem-teams
+      ],
+    },
+    {
+      type: 'category',
+      label: 'Enabling Teams',
+      link: { type: 'doc', id: 'enabling-teams/index' },
+      items: [
+        // region: enabling-teams
+        {
+          type: 'category',
+          label: 'Sophrosyne',
+          link: { type: 'doc', id: 'enabling-teams/sophrosyne/index' },
+          items: [],
+        },
+        {
+          type: 'category',
+          label: 'Soteria',
+          link: { type: 'doc', id: 'enabling-teams/soteria/index' },
+          items: [],
+        },
+        // endregion: enabling-teams
+      ],
+    },
+  ],
+};
+
+export default sidebars;

--- a/internal/spec/schema_embed.json
+++ b/internal/spec/schema_embed.json
@@ -35,7 +35,7 @@
       "pattern": "^[A-Z][A-Za-z]*( (and|[A-Z][A-Za-z]*))*$"
     },
     "display_name_comment": {
-      "description": "Optional inline comment rendered after display_name. Used for the team etymology blurb. Also used as the `description` frontmatter on the team's docs index page (rendered by render_team_docs_index); that tool requires this field.",
+      "description": "Optional inline comment rendered after display_name. Used for the team etymology blurb. Also used as the `description` frontmatter on the team's docs index page (rendered by pt-techne-mcp-server/render_team_docs_index); that tool requires this field.",
       "type": "string"
     },
     "enable_google_project": {

--- a/internal/spec/schema_embed.json
+++ b/internal/spec/schema_embed.json
@@ -35,7 +35,7 @@
       "pattern": "^[A-Z][A-Za-z]*( (and|[A-Z][A-Za-z]*))*$"
     },
     "display_name_comment": {
-      "description": "Optional inline comment rendered after display_name. Used for the team etymology blurb.",
+      "description": "Optional inline comment rendered after display_name. Used for the team etymology blurb. Also used as the `description` frontmatter on the team's docs index page (rendered by render_team_docs_index); that tool requires this field.",
       "type": "string"
     },
     "enable_google_project": {

--- a/internal/tools/docs_render_test.go
+++ b/internal/tools/docs_render_test.go
@@ -1,0 +1,145 @@
+package tools_test
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+
+	"github.com/osinfra-io/pt-techne-mcp-server/internal/spec"
+	"github.com/osinfra-io/pt-techne-mcp-server/internal/tools"
+)
+
+const sidebarsFixture = `// @ts-check
+const sidebars = {
+  docs: [
+    { items: [
+      // region: platform-teams
+      'platform-teams/logos/index',
+      // endregion: platform-teams
+    ]},
+  ],
+};
+export default sidebars;
+`
+
+func runDocsTool(t *testing.T, name string, args any) *mcp.CallToolResult {
+	t.Helper()
+	v, err := spec.NewValidator()
+	if err != nil {
+		t.Fatalf("validator: %v", err)
+	}
+	server := mcp.NewServer(&mcp.Implementation{Name: "test"}, nil)
+	tools.RenderTeamDocsIndex(server, v)
+	tools.RenderSidebarPatch(server, v)
+
+	ct, st := mcp.NewInMemoryTransports()
+	ctx := context.Background()
+	if _, err := server.Connect(ctx, st, nil); err != nil {
+		t.Fatalf("connect: %v", err)
+	}
+	client := mcp.NewClient(&mcp.Implementation{Name: "c"}, nil)
+	cs, err := client.Connect(ctx, ct, nil)
+	if err != nil {
+		t.Fatalf("client connect: %v", err)
+	}
+	defer cs.Close()
+	res, err := cs.CallTool(ctx, &mcp.CallToolParams{Name: name, Arguments: args})
+	if err != nil {
+		t.Fatalf("CallTool %s: %v", name, err)
+	}
+	return res
+}
+
+func TestRenderTeamDocsIndex_Happy(t *testing.T) {
+	res := runDocsTool(t, "render_team_docs_index", map[string]any{"spec": validSpec()})
+	if res.IsError {
+		t.Fatalf("unexpected error: %+v", res)
+	}
+	var out tools.RenderTeamDocsIndexOutput
+	if err := json.Unmarshal(structuredOrText(t, res), &out); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if out.Path != "docs/platform-teams/example/index.md" {
+		t.Errorf("path=%q", out.Path)
+	}
+	for _, want := range []string{"sidebar_label: Example", "description: An example team used in tests.", "# Example"} {
+		if !strings.Contains(out.Content, want) {
+			t.Errorf("content missing %q; got:\n%s", want, out.Content)
+		}
+	}
+}
+
+func TestRenderTeamDocsIndex_MissingDescription(t *testing.T) {
+	s := validSpec()
+	delete(s, "display_name_comment")
+	res := runDocsTool(t, "render_team_docs_index", map[string]any{"spec": s})
+	if !res.IsError {
+		t.Fatalf("expected error")
+	}
+	var e map[string]any
+	for _, c := range res.Content {
+		if tc, ok := c.(*mcp.TextContent); ok {
+			_ = json.Unmarshal([]byte(tc.Text), &e)
+			break
+		}
+	}
+	if e["code"] != "docs_input_invalid" {
+		t.Errorf("code=%v want docs_input_invalid", e["code"])
+	}
+}
+
+func TestRenderTeamDocsIndex_ValidationFailure(t *testing.T) {
+	s := validSpec()
+	s["team_key"] = "xx-bad"
+	res := runDocsTool(t, "render_team_docs_index", map[string]any{"spec": s})
+	if !res.IsError {
+		t.Fatalf("expected error")
+	}
+}
+
+func TestRenderSidebarPatch_Insert(t *testing.T) {
+	res := runDocsTool(t, "render_sidebar_patch", map[string]any{
+		"spec":                validSpec(),
+		"current_sidebars_js": sidebarsFixture,
+	})
+	if res.IsError {
+		t.Fatalf("unexpected error: %+v", res)
+	}
+	var out tools.RenderSidebarPatchOutput
+	if err := json.Unmarshal(structuredOrText(t, res), &out); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if !strings.Contains(out.Content, "'platform-teams/example/index',") {
+		t.Errorf("expected new entry; got:\n%s", out.Content)
+	}
+}
+
+func TestRenderSidebarPatch_MissingAnchors(t *testing.T) {
+	res := runDocsTool(t, "render_sidebar_patch", map[string]any{
+		"spec":                validSpec(),
+		"current_sidebars_js": "// no anchors here\n",
+	})
+	if !res.IsError {
+		t.Fatalf("expected error")
+	}
+	var e map[string]any
+	for _, c := range res.Content {
+		if tc, ok := c.(*mcp.TextContent); ok {
+			_ = json.Unmarshal([]byte(tc.Text), &e)
+			break
+		}
+	}
+	if e["code"] != "source_parse_error" {
+		t.Errorf("code=%v want source_parse_error", e["code"])
+	}
+}
+
+func TestRenderSidebarPatch_RequiresCurrentBytes(t *testing.T) {
+	res := runDocsTool(t, "render_sidebar_patch", map[string]any{"spec": validSpec()})
+	if !res.IsError {
+		t.Fatalf("expected error")
+	}
+}

--- a/internal/tools/get_team.go
+++ b/internal/tools/get_team.go
@@ -7,6 +7,7 @@ import (
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 
 	gh "github.com/osinfra-io/pt-techne-mcp-server/internal/github"
+	"github.com/osinfra-io/pt-techne-mcp-server/internal/render/docs"
 	"github.com/osinfra-io/pt-techne-mcp-server/internal/spec"
 )
 
@@ -16,11 +17,13 @@ type GetTeamInput struct {
 }
 
 // GetTeamOutput returns the parsed spec as a JSON object — the same
-// shape validate_team_spec and render_team_tfvars accept. Spec is
-// omitempty so the typed-output schema validator does not reject the
-// null body that accompanies an isError result.
+// shape validate_team_spec and render_team_tfvars accept. DocsPages
+// lists the team's existing docs pages on pt-ekklesia-docs@main (excluding
+// index.md). Spec is omitempty so the typed-output schema validator does
+// not reject the null body that accompanies an isError result.
 type GetTeamOutput struct {
-	Spec map[string]any `json:"spec,omitempty"`
+	Spec      map[string]any `json:"spec,omitempty"`
+	DocsPages []string       `json:"docs_pages,omitempty"`
 }
 
 // GetTeam registers the get_team tool. Requires GITHUB_TOKEN.
@@ -50,6 +53,25 @@ func GetTeam(s *mcp.Server, v *spec.Validator, c gh.Client) {
 		if err != nil {
 			return nil, nil, err
 		}
-		return nil, &GetTeamOutput{Spec: obj}, nil
+		// docs_pages: list the team's existing pages on pt-ekklesia-docs@main,
+		// excluding the auto-rendered index.md. Best-effort: any error
+		// (including unknown team_type or unprefixed team_key) leaves the
+		// field empty so the primary spec response still ships.
+		var pages []string
+		if section, derr := docs.SectionFor(team.TeamType); derr == nil {
+			if folder, derr := docs.TeamFolder(team.TeamKey); derr == nil {
+				dir := "docs/" + section + "/" + folder
+				names, exists, lerr := c.ListDirInRepo(ctx, gh.RepoEkklesiaDocs, dir, gh.Base)
+				if lerr == nil && exists {
+					for _, n := range names {
+						if n == "index.md" {
+							continue
+						}
+						pages = append(pages, n)
+					}
+				}
+			}
+		}
+		return nil, &GetTeamOutput{Spec: obj, DocsPages: pages}, nil
 	})
 }

--- a/internal/tools/open_team_docs_pr.go
+++ b/internal/tools/open_team_docs_pr.go
@@ -75,13 +75,13 @@ func OpenTeamDocsPR(s *mcp.Server, v *spec.Validator, c gh.Client) {
 		folder, _ := docs.TeamFolder(team.TeamKey)
 
 		branch := "team-docs/" + team.TeamKey
-		message := in.Message
-		if message == "" {
-			message = "Add docs for " + team.TeamKey
+		title := in.Message
+		if title == "" {
+			title = "Add docs for " + team.TeamKey
 		}
-		message += coAuthoredTrailer
+		message := title + coAuthoredTrailer
 
-		out, opErr := openTeamDocsPR(ctx, c, &team, indexRes, section, folder, branch, message)
+		out, opErr := openTeamDocsPR(ctx, c, &team, indexRes, section, folder, branch, title, message)
 		if opErr != nil {
 			return errResult(*opErr), nil, nil
 		}
@@ -89,7 +89,7 @@ func OpenTeamDocsPR(s *mcp.Server, v *spec.Validator, c gh.Client) {
 	})
 }
 
-func openTeamDocsPR(ctx context.Context, c gh.Client, team *spec.Team, indexRes *docs.Result, section, folder, branch, message string) (*OpenTeamDocsPROutput, *opError) {
+func openTeamDocsPR(ctx context.Context, c gh.Client, team *spec.Team, indexRes *docs.Result, section, folder, branch, title, message string) (*OpenTeamDocsPROutput, *opError) {
 	repo := gh.RepoEkklesiaDocs
 
 	openPR, err := findOpenPRInRepo(ctx, c, repo, branch)
@@ -197,7 +197,7 @@ func openTeamDocsPR(ctx context.Context, c gh.Client, team *spec.Team, indexRes 
 			IndexPath: indexRes.Path, SidebarsPath: sidebarsPath,
 		}, nil
 	}
-	pr, action, opErr := createDocsPRWithReconcile(ctx, c, repo, branch, team)
+	pr, action, opErr := createDocsPRWithReconcile(ctx, c, repo, branch, title, team)
 	if opErr != nil {
 		return nil, opErr
 	}
@@ -286,8 +286,7 @@ func commitWithRetryInRepo(ctx context.Context, c gh.Client, repo, path, branch,
 	return commitSHA, nil
 }
 
-func createDocsPRWithReconcile(ctx context.Context, c gh.Client, repo, branch string, team *spec.Team) (gh.PullRequest, string, *opError) {
-	title := "Add docs for " + team.TeamKey
+func createDocsPRWithReconcile(ctx context.Context, c gh.Client, repo, branch, title string, team *spec.Team) (gh.PullRequest, string, *opError) {
 	body := docsPRBody(team)
 	pr, err := c.CreatePRInRepo(ctx, repo, branch, gh.Base, title, body)
 	if err == nil {

--- a/internal/tools/open_team_docs_pr.go
+++ b/internal/tools/open_team_docs_pr.go
@@ -1,0 +1,317 @@
+// MCP tool: open_team_docs_pr.
+//
+// Validates the spec, renders the team's docs/<section>/<team>/index.md,
+// patches pt-ekklesia-docs/sidebars.js, and lands both files on
+// branch team-docs/<team_key> via a deterministic transaction. Same
+// idempotence semantics as open_team_pr: identical input + identical
+// repo state returns action=noop. Two files = up to two commits per call.
+package tools
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+
+	gh "github.com/osinfra-io/pt-techne-mcp-server/internal/github"
+	"github.com/osinfra-io/pt-techne-mcp-server/internal/render/docs"
+	"github.com/osinfra-io/pt-techne-mcp-server/internal/render/sidebar"
+	"github.com/osinfra-io/pt-techne-mcp-server/internal/spec"
+)
+
+// OpenTeamDocsPRInput is the input for open_team_docs_pr.
+type OpenTeamDocsPRInput struct {
+	Spec    map[string]any `json:"spec" jsonschema:"the validated team spec to commit and PR"`
+	Message string         `json:"message,omitempty" jsonschema:"optional commit/PR title override; defaults to 'Add docs for <team-key>'"`
+}
+
+// OpenTeamDocsPROutput mirrors OpenTeamPROutput. CommitSHAs holds the
+// per-file commit SHAs (index, then sidebars) when commits happened —
+// either may be empty when that file was already up to date.
+type OpenTeamDocsPROutput struct {
+	PRURL        string   `json:"pr_url"`
+	PRNumber     int      `json:"pr_number"`
+	Branch       string   `json:"branch"`
+	CommitSHAs   []string `json:"commit_shas,omitempty"`
+	Action       string   `json:"action"` // created|updated|noop
+	IndexPath    string   `json:"index_path"`
+	SidebarsPath string   `json:"sidebars_path"`
+}
+
+const sidebarsPath = "sidebars.js"
+
+// OpenTeamDocsPR registers the open_team_docs_pr tool. Like OpenTeamPR,
+// when c is nil the tool registers but every call returns not_configured.
+func OpenTeamDocsPR(s *mcp.Server, v *spec.Validator, c gh.Client) {
+	mcp.AddTool(s, &mcp.Tool{
+		Name:        "open_team_docs_pr",
+		Description: "Validate, render index.md, patch sidebars.js, and open-or-update a PR on osinfra-io/pt-ekklesia-docs for the given team spec. Idempotent. Requires GITHUB_TOKEN with write access to pt-ekklesia-docs.",
+	}, func(ctx context.Context, _ *mcp.CallToolRequest, in OpenTeamDocsPRInput) (*mcp.CallToolResult, *OpenTeamDocsPROutput, error) {
+		if c == nil {
+			return notConfigured("open_team_docs_pr"), nil, nil
+		}
+		if errs := v.Validate(in.Spec); len(errs) > 0 {
+			body, _ := json.Marshal(ValidateOutput{Valid: false, Errors: errs})
+			return &mcp.CallToolResult{IsError: true, Content: []mcp.Content{&mcp.TextContent{Text: string(body)}}}, nil, nil
+		}
+
+		raw, err := json.Marshal(in.Spec)
+		if err != nil {
+			return nil, nil, fmt.Errorf("re-marshal spec: %w", err)
+		}
+		var team spec.Team
+		if err := json.Unmarshal(raw, &team); err != nil {
+			return nil, nil, fmt.Errorf("decode validated spec: %w", err)
+		}
+
+		indexRes, err := docs.Render(&team)
+		if err != nil {
+			return errResult(opError{Code: "docs_input_invalid", Message: err.Error()}), nil, nil
+		}
+		section, _ := docs.SectionFor(team.TeamType)
+		folder, _ := docs.TeamFolder(team.TeamKey)
+
+		branch := "team-docs/" + team.TeamKey
+		message := in.Message
+		if message == "" {
+			message = "Add docs for " + team.TeamKey
+		}
+		message += coAuthoredTrailer
+
+		out, opErr := openTeamDocsPR(ctx, c, &team, indexRes, section, folder, branch, message)
+		if opErr != nil {
+			return errResult(*opErr), nil, nil
+		}
+		return nil, out, nil
+	})
+}
+
+func openTeamDocsPR(ctx context.Context, c gh.Client, team *spec.Team, indexRes *docs.Result, section, folder, branch, message string) (*OpenTeamDocsPROutput, *opError) {
+	repo := gh.RepoEkklesiaDocs
+
+	openPR, err := findOpenPRInRepo(ctx, c, repo, branch)
+	if err != nil {
+		return nil, apiError(err)
+	}
+
+	baseSHA, _, err := c.GetRefInRepo(ctx, repo, gh.Base)
+	if err != nil {
+		return nil, apiError(err)
+	}
+	if err := ensureBranchInRepo(ctx, c, repo, branch, baseSHA, openPR != nil); err != nil {
+		return nil, err
+	}
+
+	// Sidebars: derive the patched bytes from the *branch* state so the
+	// transaction stays consistent across retries; falling back to main
+	// when the branch doesn't yet have a divergent copy.
+	currentSidebars, sidebarsBlobSHA, sidebarsExists, err := c.GetFileInRepo(ctx, repo, sidebarsPath, branch)
+	if err != nil {
+		return nil, apiError(err)
+	}
+	if !sidebarsExists {
+		// Brand-new repo state — should never happen against real
+		// pt-ekklesia-docs, but keep the error structured.
+		return nil, &opError{Code: "source_parse_error", Message: "sidebars.js not found at branch " + branch}
+	}
+	patchedSidebars, err := sidebar.Render(currentSidebars, section, folder)
+	if err != nil {
+		var anchorsErr *sidebar.ErrAnchorsMissing
+		if errors.As(err, &anchorsErr) {
+			return nil, &opError{Code: "source_parse_error", Message: err.Error()}
+		}
+		return nil, &opError{Code: "render_failed", Message: err.Error()}
+	}
+
+	// Index page: get current state on branch (may be absent).
+	currentIndex, indexBlobSHA, _, err := c.GetFileInRepo(ctx, repo, indexRes.Path, branch)
+	if err != nil {
+		return nil, apiError(err)
+	}
+
+	// Compare main too — when the branch perfectly mirrors main and no
+	// PR exists, the change is already shipped.
+	mainIndex, _, _, err := c.GetFileInRepo(ctx, repo, indexRes.Path, gh.Base)
+	if err != nil {
+		return nil, apiError(err)
+	}
+	mainSidebars, _, _, err := c.GetFileInRepo(ctx, repo, sidebarsPath, gh.Base)
+	if err != nil {
+		return nil, apiError(err)
+	}
+
+	indexUpToDate := bytes.Equal(currentIndex, indexRes.Content)
+	sidebarsUpToDate := bytes.Equal(currentSidebars, patchedSidebars)
+
+	if indexUpToDate && sidebarsUpToDate && openPR != nil {
+		return &OpenTeamDocsPROutput{
+			PRURL: openPR.URL, PRNumber: openPR.Number,
+			Branch: branch, Action: "noop",
+			IndexPath: indexRes.Path, SidebarsPath: sidebarsPath,
+		}, nil
+	}
+	if openPR == nil &&
+		bytes.Equal(mainIndex, indexRes.Content) &&
+		bytes.Equal(mainSidebars, patchedSidebars) {
+		return &OpenTeamDocsPROutput{
+			Branch: branch, Action: "noop",
+			IndexPath: indexRes.Path, SidebarsPath: sidebarsPath,
+		}, nil
+	}
+
+	var commits []string
+
+	if !indexUpToDate {
+		sha, opErr := commitWithRetryInRepo(ctx, c, repo, indexRes.Path, branch, indexBlobSHA, indexRes.Content, message, openPR)
+		if opErr != nil {
+			return nil, opErr
+		}
+		if sha != "" {
+			commits = append(commits, sha)
+		}
+	}
+	if !sidebarsUpToDate {
+		// Re-fetch the sidebars blob SHA after the index commit so the
+		// next write doesn't 409 on a stale sha.
+		_, freshSHA, _, gerr := c.GetFileInRepo(ctx, repo, sidebarsPath, branch)
+		if gerr != nil {
+			return nil, apiError(gerr)
+		}
+		sha, opErr := commitWithRetryInRepo(ctx, c, repo, sidebarsPath, branch, freshSHA, patchedSidebars, message, openPR)
+		if opErr != nil {
+			return nil, opErr
+		}
+		if sha != "" {
+			commits = append(commits, sha)
+		}
+		_ = sidebarsBlobSHA // intentionally unused; freshSHA replaces it
+	}
+
+	if openPR != nil {
+		return &OpenTeamDocsPROutput{
+			PRURL: openPR.URL, PRNumber: openPR.Number,
+			Branch: branch, CommitSHAs: commits, Action: "updated",
+			IndexPath: indexRes.Path, SidebarsPath: sidebarsPath,
+		}, nil
+	}
+	pr, action, opErr := createDocsPRWithReconcile(ctx, c, repo, branch, team)
+	if opErr != nil {
+		return nil, opErr
+	}
+	return &OpenTeamDocsPROutput{
+		PRURL: pr.URL, PRNumber: pr.Number,
+		Branch: branch, CommitSHAs: commits, Action: action,
+		IndexPath: indexRes.Path, SidebarsPath: sidebarsPath,
+	}, nil
+}
+
+// The remaining helpers mirror open_team_pr.go's findOpenPR /
+// ensureBranch / commitWithRetry / createPRWithReconcile but accept a
+// repo parameter and use the *InRepo client surface.
+
+func findOpenPRInRepo(ctx context.Context, c gh.Client, repo, branch string) (*gh.PullRequest, error) {
+	prs, err := c.ListOpenPRsInRepo(ctx, repo, branch, gh.Base)
+	if err != nil {
+		return nil, err
+	}
+	if len(prs) == 0 {
+		return nil, nil
+	}
+	return &prs[0], nil
+}
+
+func ensureBranchInRepo(ctx context.Context, c gh.Client, repo, branch, baseSHA string, hasOpenPR bool) *opError {
+	_, exists, err := c.GetRefInRepo(ctx, repo, branch)
+	if err != nil {
+		return apiError(err)
+	}
+	if !exists {
+		if err := c.CreateRefInRepo(ctx, repo, branch, baseSHA); err != nil && !gh.IsConflict(err) {
+			return apiError(err)
+		}
+		return nil
+	}
+	status, err := c.CompareCommitsInRepo(ctx, repo, gh.Base, branch)
+	if err != nil {
+		return apiError(err)
+	}
+	switch status {
+	case gh.StatusIdentical, gh.StatusAhead:
+		return nil
+	case gh.StatusBehind:
+		if err := c.UpdateRefInRepo(ctx, repo, branch, baseSHA, false); err != nil {
+			return apiError(err)
+		}
+		return nil
+	case gh.StatusDiverged:
+		if hasOpenPR {
+			return &opError{
+				Code:    "branch_diverged",
+				Message: "branch " + branch + " on " + repo + " has diverged from " + gh.Base + " and an open PR exists; rebase or close the PR before retrying",
+			}
+		}
+		if err := c.DeleteRefInRepo(ctx, repo, branch); err != nil {
+			return apiError(err)
+		}
+		if err := c.CreateRefInRepo(ctx, repo, branch, baseSHA); err != nil {
+			return apiError(err)
+		}
+		return nil
+	}
+	return apiError(errors.New("unknown branch state"))
+}
+
+func commitWithRetryInRepo(ctx context.Context, c gh.Client, repo, path, branch, blobSHA string, rendered []byte, message string, openPR *gh.PullRequest) (string, *opError) {
+	commitSHA, err := c.CreateOrUpdateFileInRepo(ctx, repo, path, branch, blobSHA, rendered, message)
+	if err == nil {
+		return commitSHA, nil
+	}
+	if !gh.IsConflict(err) {
+		return "", apiError(err)
+	}
+	current, freshSHA, _, gerr := c.GetFileInRepo(ctx, repo, path, branch)
+	if gerr != nil {
+		return "", apiError(gerr)
+	}
+	if bytes.Equal(current, rendered) && openPR != nil {
+		return "", nil
+	}
+	commitSHA, err = c.CreateOrUpdateFileInRepo(ctx, repo, path, branch, freshSHA, rendered, message)
+	if err != nil {
+		return "", &opError{Code: "github_conflict", Message: err.Error(), Retryable: true}
+	}
+	return commitSHA, nil
+}
+
+func createDocsPRWithReconcile(ctx context.Context, c gh.Client, repo, branch string, team *spec.Team) (gh.PullRequest, string, *opError) {
+	title := "Add docs for " + team.TeamKey
+	body := docsPRBody(team)
+	pr, err := c.CreatePRInRepo(ctx, repo, branch, gh.Base, title, body)
+	if err == nil {
+		return pr, "created", nil
+	}
+	if !gh.IsConflict(err) {
+		return gh.PullRequest{}, "", apiError(err)
+	}
+	prs, lerr := c.ListOpenPRsInRepo(ctx, repo, branch, gh.Base)
+	if lerr != nil {
+		return gh.PullRequest{}, "", apiError(lerr)
+	}
+	if len(prs) > 0 {
+		return prs[0], "updated", nil
+	}
+	return gh.PullRequest{}, "", apiError(err)
+}
+
+func docsPRBody(t *spec.Team) string {
+	return fmt.Sprintf(
+		"Automated docs scaffold for team `%s` (`%s`).\n\n"+
+			"- Adds `docs/<section>/<team>/index.md`\n"+
+			"- Inserts the entry into `sidebars.js` (anchor-driven)\n\n"+
+			"Generated by `pt-techne-mcp-server` `open_team_docs_pr`. The page is a stub — extend it with Bounded Context, Ubiquitous Language, ADRs, etc., as that understanding lands.",
+		t.TeamKey, t.DisplayName,
+	)
+}

--- a/internal/tools/open_team_docs_pr_test.go
+++ b/internal/tools/open_team_docs_pr_test.go
@@ -1,0 +1,172 @@
+package tools_test
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+
+	gh "github.com/osinfra-io/pt-techne-mcp-server/internal/github"
+	"github.com/osinfra-io/pt-techne-mcp-server/internal/render/docs"
+	"github.com/osinfra-io/pt-techne-mcp-server/internal/spec"
+	"github.com/osinfra-io/pt-techne-mcp-server/internal/tools"
+)
+
+const docsBranch = "team-docs/pt-example"
+
+// runOpenDocsPR mirrors runOpenPR but for open_team_docs_pr.
+func runOpenDocsPR(t *testing.T, c gh.Client, args map[string]any) *mcp.CallToolResult {
+	t.Helper()
+	v, err := spec.NewValidator()
+	if err != nil {
+		t.Fatalf("validator: %v", err)
+	}
+	server := mcp.NewServer(&mcp.Implementation{Name: "test"}, nil)
+	tools.OpenTeamDocsPR(server, v, c)
+
+	ct, st := mcp.NewInMemoryTransports()
+	ctx := context.Background()
+	if _, err := server.Connect(ctx, st, nil); err != nil {
+		t.Fatalf("server.Connect: %v", err)
+	}
+	client := mcp.NewClient(&mcp.Implementation{Name: "test-client"}, nil)
+	cs, err := client.Connect(ctx, ct, nil)
+	if err != nil {
+		t.Fatalf("client.Connect: %v", err)
+	}
+	defer cs.Close()
+	res, err := cs.CallTool(ctx, &mcp.CallToolParams{Name: "open_team_docs_pr", Arguments: args})
+	if err != nil {
+		t.Fatalf("CallTool: %v", err)
+	}
+	return res
+}
+
+// docsFakeWithSidebars sets up a fakeClient pre-populated with a
+// pt-ekklesia-docs main branch and a sidebars.js with anchors. Subtests
+// flip on/off the index page and add open PRs.
+func docsFakeWithSidebars() *fakeClient {
+	f := newFake()
+	f.repoRefs[gh.RepoEkklesiaDocs+"/main"] = "main-sha"
+	// Branch starts present so ensureBranch hits the StatusIdentical
+	// branch (compareRes default) without create/delete churn.
+	f.repoRefs[gh.RepoEkklesiaDocs+"/"+docsBranch] = "main-sha"
+	f.repoFiles[gh.RepoEkklesiaDocs+"/"+sidebarsBareFixture+"@main"] = sidebarsFixture
+	f.repoFiles[gh.RepoEkklesiaDocs+"/"+sidebarsBareFixture+"@"+docsBranch] = sidebarsFixture
+	return f
+}
+
+const sidebarsBareFixture = "sidebars.js"
+
+func TestOpenDocsPR_NotConfigured(t *testing.T) {
+	res := runOpenDocsPR(t, nil, map[string]any{"spec": validSpec()})
+	e := decodeOpError(t, res)
+	if e["code"] != "not_configured" {
+		t.Fatalf("code=%v", e["code"])
+	}
+}
+
+func TestOpenDocsPR_HappyCreate(t *testing.T) {
+	f := docsFakeWithSidebars()
+	res := runOpenDocsPR(t, f, map[string]any{"spec": validSpec()})
+	if res.IsError {
+		t.Fatalf("unexpected error: %+v", res)
+	}
+	var out tools.OpenTeamDocsPROutput
+	if err := json.Unmarshal(structuredOrText(t, res), &out); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if out.Action != "created" {
+		t.Errorf("action=%q want created", out.Action)
+	}
+	if out.IndexPath != "docs/platform-teams/example/index.md" {
+		t.Errorf("index_path=%q", out.IndexPath)
+	}
+	if out.SidebarsPath != "sidebars.js" {
+		t.Errorf("sidebars_path=%q", out.SidebarsPath)
+	}
+	// Two commits expected: index + sidebars.
+	if f.committed != 2 || f.prsCreated != 1 {
+		t.Errorf("committed=%d prsCreated=%d want 2/1", f.committed, f.prsCreated)
+	}
+	if len(out.CommitSHAs) != 2 {
+		t.Errorf("commit_shas=%v", out.CommitSHAs)
+	}
+}
+
+func TestOpenDocsPR_NoopWhenAlreadyApplied(t *testing.T) {
+	f := docsFakeWithSidebars()
+	// Pre-render and pre-apply both files on main with no open PR.
+	rendered, err := docs.Render(specToTeamForTest(t, validSpec()))
+	if err != nil {
+		t.Fatalf("render: %v", err)
+	}
+	indexPath := rendered.Path
+	f.repoFiles[gh.RepoEkklesiaDocs+"/"+indexPath+"@main"] = string(rendered.Content)
+	f.repoFiles[gh.RepoEkklesiaDocs+"/"+indexPath+"@"+docsBranch] = string(rendered.Content)
+	// Pre-apply the patched sidebars on main + branch so all four
+	// comparisons hit equality.
+	patchedSidebars := patchedSidebarsForTest(t)
+	f.repoFiles[gh.RepoEkklesiaDocs+"/sidebars.js@main"] = patchedSidebars
+	f.repoFiles[gh.RepoEkklesiaDocs+"/sidebars.js@"+docsBranch] = patchedSidebars
+
+	res := runOpenDocsPR(t, f, map[string]any{"spec": validSpec()})
+	if res.IsError {
+		t.Fatalf("unexpected error: %+v", res)
+	}
+	var out tools.OpenTeamDocsPROutput
+	if err := json.Unmarshal(structuredOrText(t, res), &out); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if out.Action != "noop" {
+		t.Errorf("action=%q want noop", out.Action)
+	}
+	if f.committed != 0 || f.prsCreated != 0 {
+		t.Errorf("noop should not commit/PR; got committed=%d prsCreated=%d", f.committed, f.prsCreated)
+	}
+}
+
+func TestOpenDocsPR_MissingAnchorsSurfacedAsParseError(t *testing.T) {
+	f := newFake()
+	f.repoRefs[gh.RepoEkklesiaDocs+"/main"] = "main-sha"
+	f.repoRefs[gh.RepoEkklesiaDocs+"/"+docsBranch] = "main-sha"
+	f.repoFiles[gh.RepoEkklesiaDocs+"/sidebars.js@main"] = "// no anchors\n"
+	f.repoFiles[gh.RepoEkklesiaDocs+"/sidebars.js@"+docsBranch] = "// no anchors\n"
+	res := runOpenDocsPR(t, f, map[string]any{"spec": validSpec()})
+	e := decodeOpError(t, res)
+	if e["code"] != "source_parse_error" {
+		t.Errorf("code=%v want source_parse_error", e["code"])
+	}
+}
+
+// ---- helpers ----
+
+func specToTeamForTest(t *testing.T, m map[string]any) *spec.Team {
+	t.Helper()
+	raw, _ := json.Marshal(m)
+	var team spec.Team
+	if err := json.Unmarshal(raw, &team); err != nil {
+		t.Fatalf("decode spec: %v", err)
+	}
+	return &team
+}
+
+func patchedSidebarsForTest(t *testing.T) string {
+	t.Helper()
+	// Mirror what the renderer would produce for validSpec on the
+	// fixture: append the entry before the platform-teams endregion.
+	return `// @ts-check
+const sidebars = {
+  docs: [
+    { items: [
+      // region: platform-teams
+      'platform-teams/logos/index',
+      'platform-teams/example/index',
+      // endregion: platform-teams
+    ]},
+  ],
+};
+export default sidebars;
+`
+}

--- a/internal/tools/open_team_pr_test.go
+++ b/internal/tools/open_team_pr_test.go
@@ -22,11 +22,13 @@ import (
 // production go-github wrapper). Each field tracks calls so tests can
 // assert "no GitHub calls happened" and which paths fired.
 type fakeClient struct {
-	refs       map[string]string // branch -> SHA
-	files      map[string]string // path@ref -> content (blob SHA == content here for simplicity)
-	repoFiles  map[string]string // repo/path@ref -> content (sibling-repo reads via GetFileInRepo)
-	openPRs    []gh.PullRequest
-	compareRes gh.CompareStatus
+	refs        map[string]string // branch -> SHA
+	files       map[string]string // path@ref -> content (blob SHA == content here for simplicity)
+	repoFiles   map[string]string // repo/path@ref -> content (sibling-repo reads via GetFileInRepo)
+	repoRefs    map[string]string // repo/branch -> SHA (cross-repo write surface)
+	repoOpenPRs map[string][]gh.PullRequest
+	openPRs     []gh.PullRequest
+	compareRes  gh.CompareStatus
 
 	// fault injection
 	createPRConflictThenSucceed bool
@@ -39,10 +41,12 @@ type fakeClient struct {
 
 func newFake() *fakeClient {
 	return &fakeClient{
-		refs:      map[string]string{"main": "main-sha"},
-		files:     map[string]string{},
-		repoFiles: map[string]string{},
-		openPRs:   nil,
+		refs:        map[string]string{"main": "main-sha"},
+		files:       map[string]string{},
+		repoFiles:   map[string]string{},
+		repoRefs:    map[string]string{},
+		repoOpenPRs: map[string][]gh.PullRequest{},
+		openPRs:     nil,
 	}
 }
 
@@ -144,6 +148,92 @@ func (f *fakeClient) CreatePR(_ context.Context, _, _, _, _ string) (gh.PullRequ
 	f.prsCreated++
 	pr := gh.PullRequest{Number: 100, URL: "https://github.com/osinfra-io/pt-logos/pull/100"}
 	f.openPRs = []gh.PullRequest{pr}
+	return pr, nil
+}
+
+// Cross-repo (*InRepo) surface. Tests for open_team_docs_pr drive these
+// directly; tests for open_team_pr never touch them, so the fake can
+// hold both surfaces without coupling.
+
+func (f *fakeClient) ListDirInRepo(_ context.Context, repo, path, ref string) ([]string, bool, error) {
+	prefix := repo + "/" + path + "/"
+	suffix := "@" + ref
+	seen := map[string]struct{}{}
+	var out []string
+	for k := range f.repoFiles {
+		if !strings.HasPrefix(k, prefix) || !strings.HasSuffix(k, suffix) {
+			continue
+		}
+		name := k[len(prefix) : len(k)-len(suffix)]
+		if _, dup := seen[name]; dup {
+			continue
+		}
+		seen[name] = struct{}{}
+		out = append(out, name)
+	}
+	sort.Strings(out)
+	if len(out) == 0 {
+		return nil, false, nil
+	}
+	return out, true, nil
+}
+
+func (f *fakeClient) GetRefInRepo(_ context.Context, repo, branch string) (string, bool, error) {
+	sha, ok := f.repoRefs[repo+"/"+branch]
+	return sha, ok, nil
+}
+
+func (f *fakeClient) CreateRefInRepo(_ context.Context, repo, branch, fromSHA string) error {
+	f.created++
+	f.repoRefs[repo+"/"+branch] = fromSHA
+	return nil
+}
+
+func (f *fakeClient) UpdateRefInRepo(_ context.Context, repo, branch, toSHA string, _ bool) error {
+	f.updated++
+	f.repoRefs[repo+"/"+branch] = toSHA
+	return nil
+}
+
+func (f *fakeClient) DeleteRefInRepo(_ context.Context, repo, branch string) error {
+	f.deleted++
+	delete(f.repoRefs, repo+"/"+branch)
+	return nil
+}
+
+func (f *fakeClient) CompareCommitsInRepo(_ context.Context, _, _, _ string) (gh.CompareStatus, error) {
+	if f.compareRes == "" {
+		return gh.StatusIdentical, nil
+	}
+	return f.compareRes, nil
+}
+
+func (f *fakeClient) CreateOrUpdateFileInRepo(_ context.Context, repo, path, branch, _ string, content []byte, _ string) (string, error) {
+	if f.commitConflictThenSucceed {
+		f.commitConflictThenSucceed = false
+		if f.commitConflictMatchesAfter {
+			f.repoFiles[repo+"/"+path+"@"+branch] = string(content)
+		}
+		return "", fakeConflict()
+	}
+	f.committed++
+	f.repoFiles[repo+"/"+path+"@"+branch] = string(content)
+	return "commit-sha-" + repo + "-" + branch, nil
+}
+
+func (f *fakeClient) ListOpenPRsInRepo(_ context.Context, repo, _, _ string) ([]gh.PullRequest, error) {
+	return f.repoOpenPRs[repo], nil
+}
+
+func (f *fakeClient) CreatePRInRepo(_ context.Context, repo, _, _, _, _ string) (gh.PullRequest, error) {
+	if f.createPRConflictThenSucceed {
+		f.createPRConflictThenSucceed = false
+		f.repoOpenPRs[repo] = []gh.PullRequest{{Number: 99, URL: "https://github.com/osinfra-io/" + repo + "/pull/99"}}
+		return gh.PullRequest{}, fakeConflict()
+	}
+	f.prsCreated++
+	pr := gh.PullRequest{Number: 100, URL: "https://github.com/osinfra-io/" + repo + "/pull/100"}
+	f.repoOpenPRs[repo] = []gh.PullRequest{pr}
 	return pr, nil
 }
 

--- a/internal/tools/render_sidebar_patch.go
+++ b/internal/tools/render_sidebar_patch.go
@@ -1,0 +1,74 @@
+// MCP tool: render_sidebar_patch.
+//
+// Inserts the team's docs index entry into a provided pt-ekklesia-docs
+// sidebars.js. Stateless — the caller supplies the current bytes — so
+// the tool can be exercised against any sidebar shape (test fixtures,
+// staged edits) without touching GitHub.
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+
+	"github.com/osinfra-io/pt-techne-mcp-server/internal/render/docs"
+	"github.com/osinfra-io/pt-techne-mcp-server/internal/render/sidebar"
+	"github.com/osinfra-io/pt-techne-mcp-server/internal/spec"
+)
+
+// RenderSidebarPatchInput is the input for render_sidebar_patch.
+type RenderSidebarPatchInput struct {
+	Spec              map[string]any `json:"spec" jsonschema:"the validated team spec; section/team folder are derived from team_type and team_key"`
+	CurrentSidebarsJS string         `json:"current_sidebars_js" jsonschema:"current contents of pt-ekklesia-docs/sidebars.js"`
+}
+
+// RenderSidebarPatchOutput is the structured result.
+type RenderSidebarPatchOutput struct {
+	Content string `json:"content"`
+}
+
+// RenderSidebarPatch registers the render_sidebar_patch tool.
+func RenderSidebarPatch(s *mcp.Server, v *spec.Validator) {
+	mcp.AddTool(s, &mcp.Tool{
+		Name:        "render_sidebar_patch",
+		Description: "Insert a team's docs index entry into the supplied pt-ekklesia-docs sidebars.js, returning the patched content. Byte-stable noop when the entry is already present. Returns source_parse_error when the // region: <section> / // endregion: <section> anchors are missing.",
+	}, func(_ context.Context, _ *mcp.CallToolRequest, in RenderSidebarPatchInput) (*mcp.CallToolResult, *RenderSidebarPatchOutput, error) {
+		if errs := v.Validate(in.Spec); len(errs) > 0 {
+			body, _ := json.Marshal(ValidateOutput{Valid: false, Errors: errs})
+			return &mcp.CallToolResult{IsError: true, Content: []mcp.Content{&mcp.TextContent{Text: string(body)}}}, nil, nil
+		}
+		if in.CurrentSidebarsJS == "" {
+			return errResult(opError{Code: "invalid_input", Message: "current_sidebars_js is required"}), nil, nil
+		}
+
+		raw, err := json.Marshal(in.Spec)
+		if err != nil {
+			return nil, nil, fmt.Errorf("re-marshal spec: %w", err)
+		}
+		var team spec.Team
+		if err := json.Unmarshal(raw, &team); err != nil {
+			return nil, nil, fmt.Errorf("decode validated spec: %w", err)
+		}
+		section, err := docs.SectionFor(team.TeamType)
+		if err != nil {
+			return errResult(opError{Code: "docs_input_invalid", Message: err.Error()}), nil, nil
+		}
+		folder, err := docs.TeamFolder(team.TeamKey)
+		if err != nil {
+			return errResult(opError{Code: "docs_input_invalid", Message: err.Error()}), nil, nil
+		}
+
+		out, err := sidebar.Render([]byte(in.CurrentSidebarsJS), section, folder)
+		if err != nil {
+			var anchorsErr *sidebar.ErrAnchorsMissing
+			if errors.As(err, &anchorsErr) {
+				return errResult(opError{Code: "source_parse_error", Message: err.Error()}), nil, nil
+			}
+			return nil, nil, fmt.Errorf("render sidebar: %w", err)
+		}
+		return nil, &RenderSidebarPatchOutput{Content: string(out)}, nil
+	})
+}

--- a/internal/tools/render_team_docs_index.go
+++ b/internal/tools/render_team_docs_index.go
@@ -1,0 +1,56 @@
+// MCP tool: render_team_docs_index.
+//
+// Renders the team's docs index page for pt-ekklesia-docs. Validation
+// failures keep the same shape as validate_team_spec; the renderer also
+// requires display_name_comment to be non-empty (it's the docs page's
+// frontmatter description and body lede) and surfaces a structured
+// docs_input_invalid op error otherwise.
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+
+	"github.com/osinfra-io/pt-techne-mcp-server/internal/render/docs"
+	"github.com/osinfra-io/pt-techne-mcp-server/internal/spec"
+)
+
+// RenderTeamDocsIndexInput is the input for render_team_docs_index.
+type RenderTeamDocsIndexInput struct {
+	Spec map[string]any `json:"spec" jsonschema:"the validated team spec to render docs for"`
+}
+
+// RenderTeamDocsIndexOutput is the structured result.
+type RenderTeamDocsIndexOutput struct {
+	Path    string `json:"path"`
+	Content string `json:"content"`
+}
+
+// RenderTeamDocsIndex registers the render_team_docs_index tool.
+func RenderTeamDocsIndex(s *mcp.Server, v *spec.Validator) {
+	mcp.AddTool(s, &mcp.Tool{
+		Name:        "render_team_docs_index",
+		Description: "Validate then render a team spec to the deterministic docs/<section>/<team>/index.md page for osinfra-io/pt-ekklesia-docs. Returns {path, content}. On schema failure returns ValidateOutput; on docs-specific input failure returns docs_input_invalid.",
+	}, func(_ context.Context, _ *mcp.CallToolRequest, in RenderTeamDocsIndexInput) (*mcp.CallToolResult, *RenderTeamDocsIndexOutput, error) {
+		if errs := v.Validate(in.Spec); len(errs) > 0 {
+			body, _ := json.Marshal(ValidateOutput{Valid: false, Errors: errs})
+			return &mcp.CallToolResult{IsError: true, Content: []mcp.Content{&mcp.TextContent{Text: string(body)}}}, nil, nil
+		}
+		raw, err := json.Marshal(in.Spec)
+		if err != nil {
+			return nil, nil, fmt.Errorf("re-marshal spec: %w", err)
+		}
+		var team spec.Team
+		if err := json.Unmarshal(raw, &team); err != nil {
+			return nil, nil, fmt.Errorf("decode validated spec: %w", err)
+		}
+		res, err := docs.Render(&team)
+		if err != nil {
+			return errResult(opError{Code: "docs_input_invalid", Message: err.Error()}), nil, nil
+		}
+		return nil, &RenderTeamDocsIndexOutput{Path: res.Path, Content: string(res.Content)}, nil
+	})
+}

--- a/internal/tools/tools_test.go
+++ b/internal/tools/tools_test.go
@@ -18,7 +18,8 @@ func validSpec() map[string]any {
 		"datadog_team_memberships": map[string]any{
 			"admins": []string{"a@b.com"}, "members": []string{},
 		},
-		"display_name": "Example",
+		"display_name":         "Example",
+		"display_name_comment": "An example team used in tests.",
 		"github_parent_team_memberships": map[string]any{
 			"maintainers": []string{"x"}, "members": []string{},
 		},

--- a/schema/team.schema.json
+++ b/schema/team.schema.json
@@ -35,7 +35,7 @@
       "pattern": "^[A-Z][A-Za-z]*( (and|[A-Z][A-Za-z]*))*$"
     },
     "display_name_comment": {
-      "description": "Optional inline comment rendered after display_name. Used for the team etymology blurb. Also used as the `description` frontmatter on the team's docs index page (rendered by render_team_docs_index); that tool requires this field.",
+      "description": "Optional inline comment rendered after display_name. Used for the team etymology blurb. Also used as the `description` frontmatter on the team's docs index page (rendered by pt-techne-mcp-server/render_team_docs_index); that tool requires this field.",
       "type": "string"
     },
     "enable_google_project": {

--- a/schema/team.schema.json
+++ b/schema/team.schema.json
@@ -35,7 +35,7 @@
       "pattern": "^[A-Z][A-Za-z]*( (and|[A-Z][A-Za-z]*))*$"
     },
     "display_name_comment": {
-      "description": "Optional inline comment rendered after display_name. Used for the team etymology blurb.",
+      "description": "Optional inline comment rendered after display_name. Used for the team etymology blurb. Also used as the `description` frontmatter on the team's docs index page (rendered by render_team_docs_index); that tool requires this field.",
       "type": "string"
     },
     "enable_google_project": {


### PR DESCRIPTION
Closes #8.

Adds three MCP tools that scaffold a team's `osinfra-io/pt-ekklesia-docs` entry deterministically, mirroring the v0 schema → typed renderer → byte-stable output → transactional PR pattern already proven for tfvars.

## New tools

| Tool | Input | Output |
|---|---|---|
| `render_team_docs_index` | `{spec}` | `{path, content}` — `docs/<section>/<team>/index.md` |
| `render_sidebar_patch` | `{spec, current_sidebars_js}` | `{content}` — patched `sidebars.js` |
| `open_team_docs_pr` | `{spec, message?}` | `{pr_url, pr_number, branch, commit_shas, action, index_path, sidebars_path}` |

`open_team_docs_pr` runs both renderers and lands them on `team-docs/<team_key>` in `pt-ekklesia-docs`. Same idempotence semantics as `open_team_pr` (created / updated / noop, structured op errors).

## Other changes

- `get_team` now also returns `docs_pages` (existing pages under `docs/<section>/<team>/` on `pt-ekklesia-docs@main`, excluding `index.md`).
- `internal/github` gains a cross-repo `*InRepo` write surface so the same transaction shape works against any repo under `osinfra-io`.
- `validSpec` test fixture grows `display_name_comment` (still optional in the schema; required by the docs renderer).
- README updated: tools table, configuration section (`pt-ekklesia-docs` added to the GitHub App / fine-grained PAT scope), error code table (`docs_input_invalid` added; `source_parse_error` extended).

## Design decisions

- **Section derived from `team_type`** — `platform-team` → `platform-teams`, etc. No new schema field.
- **Team folder derived from `team_key`** — `pt-foo` → `foo`. Matches every existing folder in pt-ekklesia-docs.
- **Description sourced from `display_name_comment`** — the existing etymology blurb in pt-logos tfvars is already nearly identical to the existing pt-ekklesia-docs frontmatter `description`. Reused instead of adding a new schema field.
- **Sidebar patcher is anchor-driven** — relies on `// region: <section>` / `// endregion: <section>` markers added by osinfra-io/pt-ekklesia-docs#55. Returns `source_parse_error` if missing. Append-before-endregion (no reordering) preserves the existing semantic order in `sidebars.js`.
- **Per-file commits inside `open_team_docs_pr`** — index.md and sidebars.js land as two commits on the team-docs branch. Idempotence handles the partial-failure case via the noop short-circuit on retry.

## Dependency

Requires osinfra-io/pt-ekklesia-docs#55 (anchor markers in `sidebars.js`) to be merged before `open_team_docs_pr` and `render_sidebar_patch` can run against real data.

## Out of scope (tracked as follow-ups)

- AST-based `sidebars.js` parsing as an alternative to anchor comments.
- Auto-promotion of a plain entry to a `category` when child pages land.
- Rendering Bounded Context / Ubiquitous Language / ADRs from the spec — those aggregate from real team understanding, not the spec.

## Quality gates

`make lint`, `make test`, and `make build` all pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added three docs tools: render team docs index, generate sidebar patch, and open/manage idempotent docs PRs; team info now includes existing docs pages.

* **Documentation**
  * README updated to require a GitHub token and include the docs repo in required scopes/permissions.

* **Tests**
  * New end-to-end and unit tests covering docs rendering, sidebar patching, PR workflows, validation, and error cases.

* **Bug Fixes**
  * Expanded error codes and clearer failure reporting for docs rendering and sidebar parsing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->