### PR TITLE
Accept spec as string or object to handle LLM serialization quirks

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ Model Context Protocol (MCP) server providing platform context and tools to AI a
 
 `render_team_tfvars` validates first; on failure it returns an MCP `isError` result with the same structured errors as `validate_team_spec`.
 
+All tools that accept a `spec` parameter (`validate_team_spec`, `render_team_tfvars`, `open_team_pr`, `open_team_docs_pr`, `render_team_docs_index`, `render_sidebar_patch`) accept it as either a JSON object **or** a JSON-encoded string. This handles LLM serialization quirks where the spec is double-encoded during parallel tool calls.
+
 `open_team_pr` validates, renders, and opens-or-updates a PR on `osinfra-io/pt-logos` in one call. It is **idempotent on retry** — identical input + identical repo state returns `action: "noop"`.
 
 `list_teams`, `get_team`, `lookup_user`, and `find_repo` are pure reads against `osinfra-io/pt-logos@main` over the GitHub API. Each call fetches fresh — no in-process caching — so results always reflect the current branch state. Read tools require `GITHUB_TOKEN` for the same reason `open_team_pr` does (the repo is private to the GitHub API without authentication; even read access goes through it). Match semantics:

--- a/docs/README.md
+++ b/docs/README.md
@@ -133,6 +133,15 @@ SDK auto-derives the JSON Schema from the type — keep the struct shallow
 (no `json.RawMessage`, no embedded interfaces) so the derived schema is
 clean.
 
+**Exception: `Spec any` fields.** LLMs sometimes double-encode object
+parameters as JSON strings during parallel tool calls. The go-sdk validates
+raw JSON against the generated schema *before* unmarshaling into the handler
+struct, so `map[string]any` (which generates `{"type": "object"}`) rejects
+strings at the schema layer. Using `any` generates an unrestricted `{}`
+schema that passes both forms. All spec-accepting tools use `Spec any` +
+the `coerceSpec()` helper in `internal/tools/flex_spec.go` to normalize the
+input to `map[string]any` at handler time.
+
 ## Renderer
 
 `internal/render/render.go` is a hand-written emitter, not a `text/template`.

--- a/internal/tools/flex_spec.go
+++ b/internal/tools/flex_spec.go
@@ -11,11 +11,17 @@ import (
 func coerceSpec(raw any) (map[string]any, error) {
 	switch v := raw.(type) {
 	case map[string]any:
+		if v == nil {
+			return nil, fmt.Errorf("spec is required")
+		}
 		return v, nil
 	case string:
 		var m map[string]any
 		if err := json.Unmarshal([]byte(v), &m); err != nil {
 			return nil, fmt.Errorf("spec string is not valid JSON: %w", err)
+		}
+		if m == nil {
+			return nil, fmt.Errorf("spec string must decode to a JSON object")
 		}
 		return m, nil
 	case nil:

--- a/internal/tools/flex_spec.go
+++ b/internal/tools/flex_spec.go
@@ -1,0 +1,26 @@
+package tools
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// coerceSpec normalises a spec argument that may arrive as either a JSON
+// object (map[string]any) or a JSON-encoded string — a common LLM
+// serialisation quirk where parallel tool calls double-encode objects.
+func coerceSpec(raw any) (map[string]any, error) {
+	switch v := raw.(type) {
+	case map[string]any:
+		return v, nil
+	case string:
+		var m map[string]any
+		if err := json.Unmarshal([]byte(v), &m); err != nil {
+			return nil, fmt.Errorf("spec string is not valid JSON: %w", err)
+		}
+		return m, nil
+	case nil:
+		return nil, fmt.Errorf("spec is required")
+	default:
+		return nil, fmt.Errorf("spec must be a JSON object or a JSON string containing an object, got %T", raw)
+	}
+}

--- a/internal/tools/flex_spec.go
+++ b/internal/tools/flex_spec.go
@@ -16,12 +16,13 @@ func coerceSpec(raw any) (map[string]any, error) {
 		}
 		return v, nil
 	case string:
-		var m map[string]any
-		if err := json.Unmarshal([]byte(v), &m); err != nil {
+		var probe any
+		if err := json.Unmarshal([]byte(v), &probe); err != nil {
 			return nil, fmt.Errorf("spec string is not valid JSON: %w", err)
 		}
-		if m == nil {
-			return nil, fmt.Errorf("spec string must decode to a JSON object")
+		m, ok := probe.(map[string]any)
+		if !ok || m == nil {
+			return nil, fmt.Errorf("spec string must decode to a JSON object, got %T", probe)
 		}
 		return m, nil
 	case nil:

--- a/internal/tools/flex_spec_test.go
+++ b/internal/tools/flex_spec_test.go
@@ -55,3 +55,27 @@ func TestCoerceSpec_NullString(t *testing.T) {
 		t.Fatal("expected error for JSON null string")
 	}
 }
+
+func TestCoerceSpec_ArrayString(t *testing.T) {
+	_, err := coerceSpec(`[1, 2, 3]`)
+	if err == nil {
+		t.Fatal("expected error for JSON array string")
+	}
+	if got := err.Error(); got != `spec string must decode to a JSON object, got []interface {}` {
+		t.Fatalf("unexpected error message: %s", got)
+	}
+}
+
+func TestCoerceSpec_NumberString(t *testing.T) {
+	_, err := coerceSpec("42")
+	if err == nil {
+		t.Fatal("expected error for JSON number string")
+	}
+}
+
+func TestCoerceSpec_BoolString(t *testing.T) {
+	_, err := coerceSpec("true")
+	if err == nil {
+		t.Fatal("expected error for JSON bool string")
+	}
+}

--- a/internal/tools/flex_spec_test.go
+++ b/internal/tools/flex_spec_test.go
@@ -1,0 +1,42 @@
+package tools
+
+import (
+	"testing"
+)
+
+func TestCoerceSpec_Object(t *testing.T) {
+	in := map[string]any{"team_key": "pt-test", "display_name": "Test"}
+	out, err := coerceSpec(in)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if out["team_key"] != "pt-test" {
+		t.Fatalf("got team_key=%v, want pt-test", out["team_key"])
+	}
+}
+
+func TestCoerceSpec_String(t *testing.T) {
+	in := `{"team_key":"pt-test","display_name":"Test"}`
+	out, err := coerceSpec(in)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if out["team_key"] != "pt-test" {
+		t.Fatalf("got team_key=%v, want pt-test", out["team_key"])
+	}
+}
+
+func TestCoerceSpec_InvalidString(t *testing.T) {
+	in := "not json at all"
+	_, err := coerceSpec(in)
+	if err == nil {
+		t.Fatal("expected error for invalid JSON string")
+	}
+}
+
+func TestCoerceSpec_Nil(t *testing.T) {
+	_, err := coerceSpec(nil)
+	if err == nil {
+		t.Fatal("expected error for nil")
+	}
+}

--- a/internal/tools/flex_spec_test.go
+++ b/internal/tools/flex_spec_test.go
@@ -40,3 +40,18 @@ func TestCoerceSpec_Nil(t *testing.T) {
 		t.Fatal("expected error for nil")
 	}
 }
+
+func TestCoerceSpec_TypedNilMap(t *testing.T) {
+	var m map[string]any
+	_, err := coerceSpec(m)
+	if err == nil {
+		t.Fatal("expected error for typed nil map")
+	}
+}
+
+func TestCoerceSpec_NullString(t *testing.T) {
+	_, err := coerceSpec("null")
+	if err == nil {
+		t.Fatal("expected error for JSON null string")
+	}
+}

--- a/internal/tools/open_team_docs_pr.go
+++ b/internal/tools/open_team_docs_pr.go
@@ -24,8 +24,8 @@ import (
 
 // OpenTeamDocsPRInput is the input for open_team_docs_pr.
 type OpenTeamDocsPRInput struct {
-	Spec    map[string]any `json:"spec" jsonschema:"the validated team spec to commit and PR"`
-	Message string         `json:"message,omitempty" jsonschema:"optional commit/PR title override; defaults to 'Add docs for <team-key>'"`
+	Spec    any    `json:"spec" jsonschema:"the validated team spec to commit and PR"`
+	Message string `json:"message,omitempty" jsonschema:"optional commit/PR title override; defaults to 'Add docs for <team-key>'"`
 }
 
 // OpenTeamDocsPROutput mirrors OpenTeamPROutput. CommitSHAs holds the
@@ -53,12 +53,16 @@ func OpenTeamDocsPR(s *mcp.Server, v *spec.Validator, c gh.Client) {
 		if c == nil {
 			return notConfigured("open_team_docs_pr"), nil, nil
 		}
-		if errs := v.Validate(in.Spec); len(errs) > 0 {
+		specMap, err := coerceSpec(in.Spec)
+		if err != nil {
+			return errResult(opError{Code: "invalid_input", Message: err.Error()}), nil, nil
+		}
+		if errs := v.Validate(specMap); len(errs) > 0 {
 			body, _ := json.Marshal(ValidateOutput{Valid: false, Errors: errs})
 			return &mcp.CallToolResult{IsError: true, Content: []mcp.Content{&mcp.TextContent{Text: string(body)}}}, nil, nil
 		}
 
-		raw, err := json.Marshal(in.Spec)
+		raw, err := json.Marshal(specMap)
 		if err != nil {
 			return nil, nil, fmt.Errorf("re-marshal spec: %w", err)
 		}

--- a/internal/tools/open_team_pr.go
+++ b/internal/tools/open_team_pr.go
@@ -21,8 +21,8 @@ import (
 
 // OpenTeamPRInput is the input for open_team_pr.
 type OpenTeamPRInput struct {
-	Spec    map[string]any `json:"spec" jsonschema:"the validated team spec to commit and PR"`
-	Message string         `json:"message,omitempty" jsonschema:"optional commit/PR title override; defaults to 'Update teams/<team-key>.tfvars'"`
+	Spec    any    `json:"spec" jsonschema:"the validated team spec to commit and PR"`
+	Message string `json:"message,omitempty" jsonschema:"optional commit/PR title override; defaults to 'Update teams/<team-key>.tfvars'"`
 }
 
 // OpenTeamPROutput is the structured result of open_team_pr.
@@ -58,7 +58,11 @@ func OpenTeamPR(s *mcp.Server, v *spec.Validator, c gh.Client) {
 				Message: "open_team_pr requires GITHUB_TOKEN; see README Configuration",
 			}), nil, nil
 		}
-		if errs := v.Validate(in.Spec); len(errs) > 0 {
+		specMap, err := coerceSpec(in.Spec)
+		if err != nil {
+			return errResult(opError{Code: "invalid_input", Message: err.Error()}), nil, nil
+		}
+		if errs := v.Validate(specMap); len(errs) > 0 {
 			body, _ := json.Marshal(ValidateOutput{Valid: false, Errors: errs})
 			return &mcp.CallToolResult{
 				IsError: true,
@@ -66,7 +70,7 @@ func OpenTeamPR(s *mcp.Server, v *spec.Validator, c gh.Client) {
 			}, nil, nil
 		}
 
-		raw, err := json.Marshal(in.Spec)
+		raw, err := json.Marshal(specMap)
 		if err != nil {
 			return nil, nil, fmt.Errorf("re-marshal spec: %w", err)
 		}

--- a/internal/tools/render_sidebar_patch.go
+++ b/internal/tools/render_sidebar_patch.go
@@ -21,8 +21,8 @@ import (
 
 // RenderSidebarPatchInput is the input for render_sidebar_patch.
 type RenderSidebarPatchInput struct {
-	Spec              map[string]any `json:"spec" jsonschema:"the validated team spec; section/team folder are derived from team_type and team_key"`
-	CurrentSidebarsJS string         `json:"current_sidebars_js" jsonschema:"current contents of pt-ekklesia-docs/sidebars.js"`
+	Spec              any    `json:"spec" jsonschema:"the validated team spec; section/team folder are derived from team_type and team_key"`
+	CurrentSidebarsJS string `json:"current_sidebars_js" jsonschema:"current contents of pt-ekklesia-docs/sidebars.js"`
 }
 
 // RenderSidebarPatchOutput is the structured result.
@@ -36,7 +36,11 @@ func RenderSidebarPatch(s *mcp.Server, v *spec.Validator) {
 		Name:        "render_sidebar_patch",
 		Description: "Insert a team's docs index entry into the supplied pt-ekklesia-docs sidebars.js, returning the patched content. Byte-stable noop when the entry is already present. Returns source_parse_error when the // region: <section> / // endregion: <section> anchors are missing.",
 	}, func(_ context.Context, _ *mcp.CallToolRequest, in RenderSidebarPatchInput) (*mcp.CallToolResult, *RenderSidebarPatchOutput, error) {
-		if errs := v.Validate(in.Spec); len(errs) > 0 {
+		specMap, err := coerceSpec(in.Spec)
+		if err != nil {
+			return errResult(opError{Code: "invalid_input", Message: err.Error()}), nil, nil
+		}
+		if errs := v.Validate(specMap); len(errs) > 0 {
 			body, _ := json.Marshal(ValidateOutput{Valid: false, Errors: errs})
 			return &mcp.CallToolResult{IsError: true, Content: []mcp.Content{&mcp.TextContent{Text: string(body)}}}, nil, nil
 		}
@@ -44,7 +48,7 @@ func RenderSidebarPatch(s *mcp.Server, v *spec.Validator) {
 			return errResult(opError{Code: "invalid_input", Message: "current_sidebars_js is required"}), nil, nil
 		}
 
-		raw, err := json.Marshal(in.Spec)
+		raw, err := json.Marshal(specMap)
 		if err != nil {
 			return nil, nil, fmt.Errorf("re-marshal spec: %w", err)
 		}

--- a/internal/tools/render_team_docs_index.go
+++ b/internal/tools/render_team_docs_index.go
@@ -20,7 +20,7 @@ import (
 
 // RenderTeamDocsIndexInput is the input for render_team_docs_index.
 type RenderTeamDocsIndexInput struct {
-	Spec map[string]any `json:"spec" jsonschema:"the validated team spec to render docs for"`
+	Spec any `json:"spec" jsonschema:"the validated team spec to render docs for"`
 }
 
 // RenderTeamDocsIndexOutput is the structured result.
@@ -35,11 +35,15 @@ func RenderTeamDocsIndex(s *mcp.Server, v *spec.Validator) {
 		Name:        "render_team_docs_index",
 		Description: "Validate then render a team spec to the deterministic docs/<section>/<team>/index.md page for osinfra-io/pt-ekklesia-docs. Returns {path, content}. On schema failure returns ValidateOutput; on docs-specific input failure returns docs_input_invalid.",
 	}, func(_ context.Context, _ *mcp.CallToolRequest, in RenderTeamDocsIndexInput) (*mcp.CallToolResult, *RenderTeamDocsIndexOutput, error) {
-		if errs := v.Validate(in.Spec); len(errs) > 0 {
+		specMap, err := coerceSpec(in.Spec)
+		if err != nil {
+			return errResult(opError{Code: "invalid_input", Message: err.Error()}), nil, nil
+		}
+		if errs := v.Validate(specMap); len(errs) > 0 {
 			body, _ := json.Marshal(ValidateOutput{Valid: false, Errors: errs})
 			return &mcp.CallToolResult{IsError: true, Content: []mcp.Content{&mcp.TextContent{Text: string(body)}}}, nil, nil
 		}
-		raw, err := json.Marshal(in.Spec)
+		raw, err := json.Marshal(specMap)
 		if err != nil {
 			return nil, nil, fmt.Errorf("re-marshal spec: %w", err)
 		}

--- a/internal/tools/render_team_tfvars.go
+++ b/internal/tools/render_team_tfvars.go
@@ -14,7 +14,7 @@ import (
 
 // RenderInput is the input for render_team_tfvars.
 type RenderInput struct {
-	Spec map[string]any `json:"spec" jsonschema:"the validated team spec to render"`
+	Spec any `json:"spec" jsonschema:"the validated team spec to render"`
 }
 
 // RenderOutput is the structured result of render_team_tfvars.
@@ -30,7 +30,11 @@ func Render(s *mcp.Server, v *spec.Validator) {
 		Name:        "render_team_tfvars",
 		Description: "Validate then render a team spec to canonical pt-logos tfvars bytes. Returns {tfvars}. On validation failure, returns an isError tool result whose structured content matches validate_team_spec.",
 	}, func(_ context.Context, _ *mcp.CallToolRequest, in RenderInput) (*mcp.CallToolResult, *RenderOutput, error) {
-		if errs := v.Validate(in.Spec); len(errs) > 0 {
+		specMap, err := coerceSpec(in.Spec)
+		if err != nil {
+			return errResult(opError{Code: "invalid_input", Message: err.Error()}), nil, nil
+		}
+		if errs := v.Validate(specMap); len(errs) > 0 {
 			body, _ := json.Marshal(ValidateOutput{Valid: false, Errors: errs})
 			return &mcp.CallToolResult{
 				IsError: true,
@@ -38,7 +42,7 @@ func Render(s *mcp.Server, v *spec.Validator) {
 			}, nil, nil
 		}
 
-		raw, err := json.Marshal(in.Spec)
+		raw, err := json.Marshal(specMap)
 		if err != nil {
 			return nil, nil, fmt.Errorf("re-marshal spec: %w", err)
 		}

--- a/internal/tools/validate_team_spec.go
+++ b/internal/tools/validate_team_spec.go
@@ -18,7 +18,7 @@ import (
 // The spec is accepted as an arbitrary JSON object so callers can pass any
 // shape; validation reports errors against the schema.
 type ValidateInput struct {
-	Spec map[string]any `json:"spec" jsonschema:"the team spec object to validate"`
+	Spec any `json:"spec" jsonschema:"the team spec object to validate"`
 }
 
 // ValidateOutput is the structured result of validate_team_spec.
@@ -33,7 +33,14 @@ func Validate(s *mcp.Server, v *spec.Validator) {
 		Name:        "validate_team_spec",
 		Description: "Validate a team spec object against schema/team.schema.json. Returns {valid, errors[]} with structured per-field errors. Never throws.",
 	}, func(_ context.Context, _ *mcp.CallToolRequest, in ValidateInput) (*mcp.CallToolResult, *ValidateOutput, error) {
-		errs := v.Validate(in.Spec)
+		specMap, err := coerceSpec(in.Spec)
+		if err != nil {
+			return nil, &ValidateOutput{
+				Valid:  false,
+				Errors: []spec.ValidationError{{Path: "", Message: err.Error()}},
+			}, nil
+		}
+		errs := v.Validate(specMap)
 		return nil, &ValidateOutput{
 			Valid:  len(errs) == 0,
 			Errors: errs,


### PR DESCRIPTION
## Problem

When LLMs make parallel tool calls, they sometimes double-encode the `spec` parameter as a JSON string instead of passing it as an object. The go-sdk validates raw JSON against the generated schema *before* unmarshaling into the handler struct, so a `map[string]any` field (which generates `{"type": "object"}` schema) rejects strings at the schema layer — before our code ever runs.

## Fix

- Changed `Spec` field type from `map[string]any` to `any` (generates unrestricted `{}` schema)
- Added `coerceSpec()` helper that accepts both `map[string]any` (direct) and `string` (JSON-parses it)
- Applied to all 6 spec-accepting tools: `open_team_pr`, `open_team_docs_pr`, `render_team_tfvars`, `validate_team_spec`, `render_sidebar_patch`, `render_team_docs_index`
- Added tests covering object input, string input, invalid string, and nil

## Testing

```
go test ./internal/tools/ -run TestCoerceSpec -v
```

All 4 cases pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Tool specifications now accept input in multiple formats for greater flexibility

* **Improvements**
  * Enhanced validation and error handling for specification inputs
  * Consistent error messaging across all specification-based tools

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/osinfra-io/pt-techne-mcp-server/pull/22?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->