### PR TITLE
Stop MCP SDK shadowing tool errors with empty structured output

### DIFF
--- a/internal/tools/find_repo.go
+++ b/internal/tools/find_repo.go
@@ -37,7 +37,7 @@ func FindRepo(s *mcp.Server, v *spec.Validator, c gh.Client) {
 			Title:        "Find repository owner",
 			ReadOnlyHint: true,
 		},
-	}, func(ctx context.Context, _ *mcp.CallToolRequest, in FindRepoInput) (*mcp.CallToolResult, *FindRepoOutput, error) {
+	}, func(ctx context.Context, _ *mcp.CallToolRequest, in FindRepoInput) (*mcp.CallToolResult, any, error) {
 		if c == nil {
 			return notConfigured("find_repo"), nil, nil
 		}

--- a/internal/tools/get_team.go
+++ b/internal/tools/get_team.go
@@ -35,7 +35,7 @@ func GetTeam(s *mcp.Server, v *spec.Validator, c gh.Client) {
 			Title:        "Get team",
 			ReadOnlyHint: true,
 		},
-	}, func(ctx context.Context, _ *mcp.CallToolRequest, in GetTeamInput) (*mcp.CallToolResult, *GetTeamOutput, error) {
+	}, func(ctx context.Context, _ *mcp.CallToolRequest, in GetTeamInput) (*mcp.CallToolResult, any, error) {
 		if c == nil {
 			return notConfigured("get_team"), nil, nil
 		}

--- a/internal/tools/list_teams.go
+++ b/internal/tools/list_teams.go
@@ -46,7 +46,7 @@ func ListTeams(s *mcp.Server, v *spec.Validator, c gh.Client) {
 			Title:        "List teams",
 			ReadOnlyHint: true,
 		},
-	}, func(ctx context.Context, _ *mcp.CallToolRequest, _ ListTeamsInput) (*mcp.CallToolResult, *ListTeamsOutput, error) {
+	}, func(ctx context.Context, _ *mcp.CallToolRequest, _ ListTeamsInput) (*mcp.CallToolResult, any, error) {
 		if c == nil {
 			return notConfigured("list_teams"), nil, nil
 		}

--- a/internal/tools/lookup_user.go
+++ b/internal/tools/lookup_user.go
@@ -64,7 +64,7 @@ func LookupUser(s *mcp.Server, v *spec.Validator, c gh.Client) {
 			Title:        "Look up user",
 			ReadOnlyHint: true,
 		},
-	}, func(ctx context.Context, _ *mcp.CallToolRequest, in LookupUserInput) (*mcp.CallToolResult, *LookupUserOutput, error) {
+	}, func(ctx context.Context, _ *mcp.CallToolRequest, in LookupUserInput) (*mcp.CallToolResult, any, error) {
 		if c == nil {
 			return notConfigured("lookup_user"), nil, nil
 		}

--- a/internal/tools/open_team_docs_pr.go
+++ b/internal/tools/open_team_docs_pr.go
@@ -53,7 +53,12 @@ func OpenTeamDocsPR(s *mcp.Server, v *spec.Validator, c gh.Client) {
 			Title:        "Open team docs PR",
 			ReadOnlyHint: false,
 		},
-	}, func(ctx context.Context, _ *mcp.CallToolRequest, in OpenTeamDocsPRInput) (*mcp.CallToolResult, *OpenTeamDocsPROutput, error) {
+		// Out is intentionally typed as `any` (not *OpenTeamDocsPROutput) so the
+		// MCP go-sdk does not substitute a zero-value struct into
+		// StructuredContent on error paths (server.go:362-369), which would
+		// otherwise shadow our errResult body for clients that read structured
+		// content. See issue #21.
+	}, func(ctx context.Context, _ *mcp.CallToolRequest, in OpenTeamDocsPRInput) (*mcp.CallToolResult, any, error) {
 		if c == nil {
 			return notConfigured("open_team_docs_pr"), nil, nil
 		}

--- a/internal/tools/open_team_pr.go
+++ b/internal/tools/open_team_pr.go
@@ -55,7 +55,8 @@ func OpenTeamPR(s *mcp.Server, v *spec.Validator, c gh.Client) {
 			Title:        "Open team PR",
 			ReadOnlyHint: false,
 		},
-	}, func(ctx context.Context, _ *mcp.CallToolRequest, in OpenTeamPRInput) (*mcp.CallToolResult, *OpenTeamPROutput, error) {
+		// See open_team_docs_pr.go for why Out is `any` instead of *OpenTeamPROutput.
+	}, func(ctx context.Context, _ *mcp.CallToolRequest, in OpenTeamPRInput) (*mcp.CallToolResult, any, error) {
 		if c == nil {
 			return errResult(opError{
 				Code:    "not_configured",

--- a/internal/tools/render_corpus_helpers.go
+++ b/internal/tools/render_corpus_helpers.go
@@ -36,18 +36,18 @@ func RenderCorpusHelpers(s *mcp.Server, c gh.Client) {
 			Title:        "Render corpus helpers",
 			ReadOnlyHint: true,
 		},
-	}, func(ctx context.Context, _ *mcp.CallToolRequest, in RenderCorpusHelpersInput) (*mcp.CallToolResult, *RenderCorpusHelpersOutput, error) {
-		return renderHelpersTool(ctx, c, "render_corpus_helpers", "pt-corpus", in.TeamKey, func(b []byte) *RenderCorpusHelpersOutput {
+	}, func(ctx context.Context, _ *mcp.CallToolRequest, in RenderCorpusHelpersInput) (*mcp.CallToolResult, any, error) {
+		return renderHelpersTool(ctx, c, "render_corpus_helpers", "pt-corpus", in.TeamKey, func(b []byte) any {
 			return &RenderCorpusHelpersOutput{HelpersTofu: string(b)}
 		})
 	})
 }
 
 // renderHelpersTool is the shared body for render_corpus_helpers and
-// render_pneuma_helpers. Inlined into both adapters via a generic
-// callback so the typed output struct stays per-tool (the MCP SDK
-// derives schemas from the concrete struct).
-func renderHelpersTool[T any](ctx context.Context, c gh.Client, toolName, repo, teamKey string, wrap func([]byte) *T) (*mcp.CallToolResult, *T, error) {
+// render_pneuma_helpers. The wrap callback keeps each tool's concrete
+// output struct intact for clients while the handler's Out type stays
+// `any` — see open_team_docs_pr.go (issue #21) for why.
+func renderHelpersTool(ctx context.Context, c gh.Client, toolName, repo, teamKey string, wrap func([]byte) any) (*mcp.CallToolResult, any, error) {
 	if c == nil {
 		return notConfigured(toolName), nil, nil
 	}

--- a/internal/tools/render_pneuma_helpers.go
+++ b/internal/tools/render_pneuma_helpers.go
@@ -34,8 +34,8 @@ func RenderPneumaHelpers(s *mcp.Server, c gh.Client) {
 			Title:        "Render pneuma helpers",
 			ReadOnlyHint: true,
 		},
-	}, func(ctx context.Context, _ *mcp.CallToolRequest, in RenderPneumaHelpersInput) (*mcp.CallToolResult, *RenderPneumaHelpersOutput, error) {
-		return renderHelpersTool(ctx, c, "render_pneuma_helpers", "pt-pneuma", in.TeamKey, func(b []byte) *RenderPneumaHelpersOutput {
+	}, func(ctx context.Context, _ *mcp.CallToolRequest, in RenderPneumaHelpersInput) (*mcp.CallToolResult, any, error) {
+		return renderHelpersTool(ctx, c, "render_pneuma_helpers", "pt-pneuma", in.TeamKey, func(b []byte) any {
 			return &RenderPneumaHelpersOutput{HelpersTofu: string(b)}
 		})
 	})

--- a/internal/tools/structured_content_shadow_test.go
+++ b/internal/tools/structured_content_shadow_test.go
@@ -1,0 +1,63 @@
+// Regression tests for issue #21.
+//
+// The MCP go-sdk (server.go:362-369 in v1.6.1) substitutes a zero-value
+// element when a typed-pointer Out handler returns nil for output. That
+// zero value was being marshalled into CallToolResult.StructuredContent
+// on error paths, shadowing the opError JSON body that errResult/notConfigured
+// emit via Content. MCP clients that read structured content (most do)
+// therefore saw `{"action":"","branch":"",...}` and never the actual error.
+//
+// The fix is to declare Out as `any` on every tool handler that uses
+// errResult/notConfigured. With Out=any the SDK skips the zero-value
+// substitution and StructuredContent stays unset. These tests pin that
+// behaviour: if anyone re-introduces a typed pointer Out on these tools,
+// StructuredContent will start coming back non-nil and these tests fail.
+package tools_test
+
+import (
+	"testing"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+func assertNoStructuredShadow(t *testing.T, name string, res *mcp.CallToolResult) {
+	t.Helper()
+	if !res.IsError {
+		t.Fatalf("%s: expected IsError result, got success: %+v", name, res)
+	}
+	if res.StructuredContent != nil {
+		t.Errorf("%s: StructuredContent must be nil on error paths so the "+
+			"opError JSON in Content is not shadowed for MCP clients; got %T(%v)",
+			name, res.StructuredContent, res.StructuredContent)
+	}
+	// Sanity-check: the error body is still reachable via Content.
+	var sawText bool
+	for _, c := range res.Content {
+		if _, ok := c.(*mcp.TextContent); ok {
+			sawText = true
+			break
+		}
+	}
+	if !sawText {
+		t.Errorf("%s: error result must carry a TextContent body", name)
+	}
+}
+
+func TestNoStructuredShadow_OpenDocsPR_NotConfigured(t *testing.T) {
+	res := runOpenDocsPR(t, nil, map[string]any{"spec": validSpec()})
+	assertNoStructuredShadow(t, "open_team_docs_pr/not_configured", res)
+}
+
+func TestNoStructuredShadow_OpenDocsPR_SourceParseError(t *testing.T) {
+	// docsFakeWithSidebars + sidebars without anchors triggers source_parse_error.
+	f := docsFakeWithSidebars()
+	f.repoFiles["pt-ekklesia-docs/sidebars.js@main"] = "// no anchors\n"
+	f.repoFiles["pt-ekklesia-docs/sidebars.js@"+docsBranch] = "// no anchors\n"
+	res := runOpenDocsPR(t, f, map[string]any{"spec": validSpec()})
+	assertNoStructuredShadow(t, "open_team_docs_pr/source_parse_error", res)
+}
+
+func TestNoStructuredShadow_OpenPR_NotConfigured(t *testing.T) {
+	res := runOpenPR(t, nil, map[string]any{"spec": validSpec()})
+	assertNoStructuredShadow(t, "open_team_pr/not_configured", res)
+}


### PR DESCRIPTION
Fixes #21.

## Root cause

The MCP go-sdk (`github.com/modelcontextprotocol/go-sdk@v1.6.1`, `mcp/server.go:362-369`) substitutes a non-nil zero value of the element type whenever a typed-pointer `Out` handler returns `nil` for output, then writes it to `CallToolResult.StructuredContent`. That zero struct was shadowing the structured opError JSON body that `errResult` / `notConfigured` emit via `Content` on every error path.

MCP clients that read `structuredContent` (most do) therefore saw responses like:

```json
{"action":"","branch":"","index_path":"","pr_number":0,"pr_url":"","sidebars_path":""}
```

…with no indication of the underlying failure. This is exactly the symptom in #21 for `open_team_docs_pr`. The same bug latently affected every other tool that uses `errResult` / `notConfigured` — it only surfaced loudly here because this tool was the first to hit a real production error path. `open_team_pr` looked fine only because the user had only ever exercised its success path.

The pre-existing comment in `open_team_pr_test.go:287-289` already documents awareness of this masking, but only the test helper sidestepped it — real MCP clients were still broken.

## Fix

Declare `Out` as `any` on every tool handler that uses `errResult` or `notConfigured`:

- `open_team_docs_pr`
- `open_team_pr`
- `find_repo`
- `get_team`
- `list_teams`
- `lookup_user`
- `render_corpus_helpers` / `render_pneuma_helpers` (via the shared `renderHelpersTool` helper, which loses its `[T any]` type parameter)

With `Out = any` and no provided `OutputSchema`, the SDK takes the `elemZero == nil` branch and skips the zero-value substitution entirely. A nil output from the handler leaves `StructuredContent` unset, so the `IsError + Content` body reaches the client intact.

Success paths still return the populated concrete struct as `any`; wire output on success is byte-for-byte unchanged.

## Regression test

Adds `internal/tools/structured_content_shadow_test.go` pinning `res.StructuredContent == nil` for several error paths (`not_configured`, `source_parse_error`). Without it, the existing `decodeOpError` helper would let the bug slip back in — it reads `Content` directly and so always sees the real error, even when the shadow is present for clients.

## Validation

- `go build ./...` ✅
- `go test ./...` ✅ (all existing tests pass, 3 new regression tests added)
- `pre-commit run -a` ✅

## Follow-up

The masking fix unblocks visibility into the *actual* failure inside `open_team_docs_pr`. The next call from a real MCP client will now surface the underlying opError code/message; we can iterate from there in a follow-up PR once we know what GitHub API call is failing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added regression tests to validate error handling and reporting across team documentation and pull request creation tools, covering configuration and validation failures.

* **Chores**
  * Standardized MCP tool handler type registrations for consistency.
  * Marked find_repo tool with read-only annotation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/osinfra-io/pt-techne-mcp-server/pull/27?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->