### PR TITLE
Add optional branch and labels inputs to open_team_pr and open_team_docs_pr

### DIFF
--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -84,6 +84,8 @@ type Client interface {
 	CreateOrUpdateFile(ctx context.Context, path, branch, blobSHA string, content []byte, message string) (commitSHA string, err error)
 	ListOpenPRs(ctx context.Context, head, base string) ([]PullRequest, error)
 	CreatePR(ctx context.Context, head, base, title, body string) (PullRequest, error)
+	AddLabels(ctx context.Context, prNumber int, labels []string) error
+	AddLabelsInRepo(ctx context.Context, repo string, prNumber int, labels []string) error
 }
 
 // New returns a Client backed by go-github authenticated with the given
@@ -376,4 +378,20 @@ func IsConflict(err error) bool {
 	}
 	return er.Response.StatusCode == http.StatusConflict ||
 		er.Response.StatusCode == http.StatusUnprocessableEntity
+}
+
+func (c *goClient) AddLabels(ctx context.Context, prNumber int, labels []string) error {
+	_, _, err := c.api.Issues.AddLabelsToIssue(ctx, Owner, Repo, prNumber, labels)
+	if err != nil {
+		return fmt.Errorf("add labels to issue #%d in %s: %w", prNumber, Repo, err)
+	}
+	return nil
+}
+
+func (c *goClient) AddLabelsInRepo(ctx context.Context, repo string, prNumber int, labels []string) error {
+	_, _, err := c.api.Issues.AddLabelsToIssue(ctx, Owner, repo, prNumber, labels)
+	if err != nil {
+		return fmt.Errorf("add labels to issue #%d in %s: %w", prNumber, repo, err)
+	}
+	return nil
 }

--- a/internal/tools/open_team_docs_pr.go
+++ b/internal/tools/open_team_docs_pr.go
@@ -13,6 +13,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 
@@ -24,8 +25,10 @@ import (
 
 // OpenTeamDocsPRInput is the input for open_team_docs_pr.
 type OpenTeamDocsPRInput struct {
-	Spec    any    `json:"spec" jsonschema:"the validated team spec to commit and PR"`
-	Message string `json:"message,omitempty" jsonschema:"optional commit/PR title override; defaults to 'Add docs for <team-key>'"`
+	Spec    any      `json:"spec" jsonschema:"the validated team spec to commit and PR"`
+	Message string   `json:"message,omitempty" jsonschema:"optional commit/PR title override; defaults to 'Add docs for <team-key>'"`
+	Branch  string   `json:"branch,omitempty" jsonschema:"optional branch name override; defaults to 'team-docs/<team-key>'"`
+	Labels  []string `json:"labels,omitempty" jsonschema:"optional labels to apply to the PR"`
 }
 
 // OpenTeamDocsPROutput mirrors OpenTeamPROutput. CommitSHAs holds the
@@ -96,7 +99,13 @@ func OpenTeamDocsPR(s *mcp.Server, v *spec.Validator, c gh.Client) {
 			return errResult(opError{Code: "docs_input_invalid", Message: err.Error()}), nil, nil
 		}
 
-		branch := "team-docs/" + team.TeamKey
+		branch := strings.TrimSpace(in.Branch)
+		if branch == "" {
+			branch = "team-docs/" + team.TeamKey
+		}
+		if branch == gh.Base {
+			return errResult(opError{Code: "invalid_input", Message: "branch must not be the base branch (\"" + gh.Base + "\")"}), nil, nil
+		}
 		title := in.Message
 		if title == "" {
 			title = "Add docs for " + team.TeamKey
@@ -106,6 +115,9 @@ func OpenTeamDocsPR(s *mcp.Server, v *spec.Validator, c gh.Client) {
 		out, opErr := openTeamDocsPR(ctx, c, &team, indexRes, section, folder, branch, title, message)
 		if opErr != nil {
 			return errResult(*opErr), nil, nil
+		}
+		if len(in.Labels) > 0 && out.PRNumber > 0 {
+			_ = c.AddLabelsInRepo(ctx, gh.RepoEkklesiaDocs, out.PRNumber, in.Labels)
 		}
 		return nil, out, nil
 	})

--- a/internal/tools/open_team_docs_pr_test.go
+++ b/internal/tools/open_team_docs_pr_test.go
@@ -175,3 +175,53 @@ const sidebars = {
 export default sidebars;
 `
 }
+
+func TestOpenDocsPR_CustomBranch(t *testing.T) {
+	f := docsFakeWithSidebars()
+	// Also seed the custom branch in repoRefs so ensureBranch succeeds.
+	f.repoRefs[gh.RepoEkklesiaDocs+"/onboard/pt-example-docs"] = "main-sha"
+	f.repoFiles[gh.RepoEkklesiaDocs+"/sidebars.js@onboard/pt-example-docs"] = sidebarsFixture
+	res := runOpenDocsPR(t, f, map[string]any{
+		"spec":   validSpec(),
+		"branch": "onboard/pt-example-docs",
+	})
+	if res.IsError {
+		t.Fatalf("unexpected error: %+v", res)
+	}
+	var out tools.OpenTeamDocsPROutput
+	if err := json.Unmarshal(structuredOrText(t, res), &out); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if out.Branch != "onboard/pt-example-docs" {
+		t.Fatalf("expected branch=onboard/pt-example-docs, got %q", out.Branch)
+	}
+}
+
+func TestOpenDocsPR_LabelsApplied(t *testing.T) {
+	f := docsFakeWithSidebars()
+	res := runOpenDocsPR(t, f, map[string]any{
+		"spec":   validSpec(),
+		"labels": []string{"nomos"},
+	})
+	if res.IsError {
+		t.Fatalf("unexpected error: %+v", res)
+	}
+	if len(f.labelsAdded) != 1 || f.labelsAdded[0] != "nomos" {
+		t.Fatalf("expected labels=[nomos], got %v", f.labelsAdded)
+	}
+}
+
+func TestOpenDocsPR_RejectMainBranch(t *testing.T) {
+	f := docsFakeWithSidebars()
+	res := runOpenDocsPR(t, f, map[string]any{
+		"spec":   validSpec(),
+		"branch": "main",
+	})
+	e := decodeOpError(t, res)
+	if e["code"] != "invalid_input" {
+		t.Fatalf("expected code=invalid_input, got %v", e["code"])
+	}
+	if f.created+f.committed+f.prsCreated > 0 {
+		t.Fatal("rejected branch must not trigger GitHub calls")
+	}
+}

--- a/internal/tools/open_team_pr.go
+++ b/internal/tools/open_team_pr.go
@@ -11,6 +11,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 
@@ -21,8 +22,10 @@ import (
 
 // OpenTeamPRInput is the input for open_team_pr.
 type OpenTeamPRInput struct {
-	Spec    any    `json:"spec" jsonschema:"the validated team spec to commit and PR"`
-	Message string `json:"message,omitempty" jsonschema:"optional commit/PR title override; defaults to 'Update teams/<team-key>.tfvars'"`
+	Spec    any      `json:"spec" jsonschema:"the validated team spec to commit and PR"`
+	Message string   `json:"message,omitempty" jsonschema:"optional commit/PR title override; defaults to 'Update teams/<team-key>.tfvars'"`
+	Branch  string   `json:"branch,omitempty" jsonschema:"optional branch name override; defaults to 'team/<team-key>'"`
+	Labels  []string `json:"labels,omitempty" jsonschema:"optional labels to apply to the PR"`
 }
 
 // OpenTeamPROutput is the structured result of open_team_pr.
@@ -91,7 +94,13 @@ func OpenTeamPR(s *mcp.Server, v *spec.Validator, c gh.Client) {
 			return nil, nil, fmt.Errorf("render team: %w", err)
 		}
 
-		branch := "team/" + team.TeamKey
+		branch := strings.TrimSpace(in.Branch)
+		if branch == "" {
+			branch = "team/" + team.TeamKey
+		}
+		if branch == gh.Base {
+			return errResult(opError{Code: "invalid_input", Message: "branch must not be the base branch (\"" + gh.Base + "\")"}), nil, nil
+		}
 		path := "teams/" + team.TeamKey + ".tfvars"
 		message := in.Message
 		if message == "" {
@@ -102,6 +111,9 @@ func OpenTeamPR(s *mcp.Server, v *spec.Validator, c gh.Client) {
 		out, opErr := openTeamPR(ctx, c, &team, rendered, branch, path, message)
 		if opErr != nil {
 			return errResult(*opErr), nil, nil
+		}
+		if len(in.Labels) > 0 && out.PRNumber > 0 {
+			_ = c.AddLabels(ctx, out.PRNumber, in.Labels)
 		}
 		return nil, out, nil
 	})

--- a/internal/tools/open_team_pr_test.go
+++ b/internal/tools/open_team_pr_test.go
@@ -37,6 +37,7 @@ type fakeClient struct {
 
 	// call counters
 	created, deleted, updated, committed, prsCreated int
+	labelsAdded                                      []string // labels applied across all AddLabels calls
 }
 
 func newFake() *fakeClient {
@@ -235,6 +236,16 @@ func (f *fakeClient) CreatePRInRepo(_ context.Context, repo, _, _, _, _ string) 
 	pr := gh.PullRequest{Number: 100, URL: "https://github.com/osinfra-io/" + repo + "/pull/100"}
 	f.repoOpenPRs[repo] = []gh.PullRequest{pr}
 	return pr, nil
+}
+
+func (f *fakeClient) AddLabels(_ context.Context, _ int, labels []string) error {
+	f.labelsAdded = append(f.labelsAdded, labels...)
+	return nil
+}
+
+func (f *fakeClient) AddLabelsInRepo(_ context.Context, _ string, _ int, labels []string) error {
+	f.labelsAdded = append(f.labelsAdded, labels...)
+	return nil
 }
 
 func fakeConflict() error {
@@ -512,4 +523,92 @@ func renderFor(t *testing.T, in map[string]any) []byte {
 		t.Fatal(err)
 	}
 	return out
+}
+
+func TestOpenPR_CustomBranch(t *testing.T) {
+	f := newFake()
+	f.compareRes = gh.StatusIdentical
+	res := runOpenPR(t, f, map[string]any{
+		"spec":   validSpec(),
+		"branch": "onboard/pt-example",
+	})
+	if res.IsError {
+		t.Fatalf("unexpected error: %+v", res)
+	}
+	out := decodeOutput(t, res)
+	if out.Branch != "onboard/pt-example" {
+		t.Fatalf("expected branch=onboard/pt-example, got %q", out.Branch)
+	}
+	if out.Action != "created" {
+		t.Fatalf("expected action=created, got %q", out.Action)
+	}
+	// Verify the branch was created with the custom name
+	if _, ok := f.refs["onboard/pt-example"]; !ok {
+		t.Fatal("expected ref onboard/pt-example to be created")
+	}
+}
+
+func TestOpenPR_RejectMainBranch(t *testing.T) {
+	f := newFake()
+	res := runOpenPR(t, f, map[string]any{
+		"spec":   validSpec(),
+		"branch": "main",
+	})
+	e := decodeOpError(t, res)
+	if e["code"] != "invalid_input" {
+		t.Fatalf("expected code=invalid_input, got %v", e["code"])
+	}
+	if f.created+f.committed+f.prsCreated > 0 {
+		t.Fatal("rejected branch must not trigger GitHub calls")
+	}
+}
+
+func TestOpenPR_LabelsAppliedOnCreate(t *testing.T) {
+	f := newFake()
+	f.compareRes = gh.StatusIdentical
+	res := runOpenPR(t, f, map[string]any{
+		"spec":   validSpec(),
+		"labels": []string{"nomos"},
+	})
+	if res.IsError {
+		t.Fatalf("unexpected error: %+v", res)
+	}
+	if len(f.labelsAdded) != 1 || f.labelsAdded[0] != "nomos" {
+		t.Fatalf("expected labels=[nomos], got %v", f.labelsAdded)
+	}
+}
+
+func TestOpenPR_LabelsAppliedOnNoop(t *testing.T) {
+	f := newFake()
+	rendered := renderFor(t, validSpec())
+	f.refs["team/pt-example"] = "branch-sha"
+	f.files["teams/pt-example.tfvars@team/pt-example"] = string(rendered)
+	f.compareRes = gh.StatusAhead
+	f.openPRs = []gh.PullRequest{{Number: 7, URL: "url-7"}}
+	res := runOpenPR(t, f, map[string]any{
+		"spec":   validSpec(),
+		"labels": []string{"nomos", "onboarding"},
+	})
+	if res.IsError {
+		t.Fatalf("unexpected error: %+v", res)
+	}
+	out := decodeOutput(t, res)
+	if out.Action != "noop" {
+		t.Fatalf("expected noop, got %q", out.Action)
+	}
+	if len(f.labelsAdded) != 2 {
+		t.Fatalf("expected 2 labels on noop, got %v", f.labelsAdded)
+	}
+}
+
+func TestOpenPR_NoLabelsWhenEmpty(t *testing.T) {
+	f := newFake()
+	f.compareRes = gh.StatusIdentical
+	res := runOpenPR(t, f, map[string]any{"spec": validSpec()})
+	if res.IsError {
+		t.Fatalf("unexpected error: %+v", res)
+	}
+	if len(f.labelsAdded) != 0 {
+		t.Fatalf("expected no labels when not specified, got %v", f.labelsAdded)
+	}
 }


### PR DESCRIPTION
## Summary

Both `open_team_pr` and `open_team_docs_pr` now accept optional input fields:

- **`branch`** — overrides the default branch name (`team/{team-key}` or `team-docs/{team-key}`). This lets the nomos agent pass the correct branch convention (`onboard/{team-key}`, `update/{team-key}`, etc.) without coupling server logic to agent prompt conventions.

- **`labels`** — a string array of labels to apply (best-effort) to the PR after creation or when an existing PR is found (including `noop` paths).

## Changes

- `internal/github/client.go`: Added `AddLabels` and `AddLabelsInRepo` to the `Client` interface + `goClient` implementation (using `IssuesService.AddLabelsToIssue`)
- `internal/tools/open_team_pr.go`: Added `Branch` and `Labels` to `OpenTeamPRInput`; uses custom branch if set, applies labels after success
- `internal/tools/open_team_docs_pr.go`: Same for `OpenTeamDocsPRInput`
- Tests: 6 new test cases covering custom branch, label application on create/noop, and no-labels-when-empty

## Backward Compatibility

- Omitting `branch` preserves existing defaults
- Omitting `labels` has no effect
- Labels are best-effort (failure to label doesn't fail the operation)

Closes #26

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Team PR and team-docs PR flows accept optional custom branch names and optional labels; provided labels are applied to the created or updated PR.
  * Labeling can target PRs in a sibling repository so labels may be added across repos.

* **Tests**
  * Added tests for custom-branch behavior, rejection of main/base branch, and label application across create/no-op flows.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/osinfra-io/pt-techne-mcp-server/pull/28?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->