### PR TITLE
Add next_available_cidrs tool to compute unallocated GKE subnet CIDR slots

### DIFF
--- a/cmd/pt-techne-mcp-server/main.go
+++ b/cmd/pt-techne-mcp-server/main.go
@@ -10,6 +10,7 @@
 //   - get_team                — parsed spec + docs_pages for one team (requires GITHUB_TOKEN)
 //   - lookup_user             — every team and role a user appears in (requires GITHUB_TOKEN)
 //   - find_repo               — which team owns a github repository (requires GITHUB_TOKEN)
+//   - next_available_cidrs    — compute next N unallocated GKE subnet CIDR slots (requires GITHUB_TOKEN)
 //   - render_corpus_helpers   — insert a team's main-production workspace into
 //     osinfra-io/pt-corpus/helpers.tofu (requires GITHUB_TOKEN)
 //   - render_pneuma_helpers   — same for osinfra-io/pt-pneuma/helpers.tofu (requires GITHUB_TOKEN)
@@ -62,6 +63,7 @@ func main() {
 	tools.GetTeam(server, v, ghClient)
 	tools.LookupUser(server, v, ghClient)
 	tools.FindRepo(server, v, ghClient)
+	tools.NextAvailableCidrs(server, v, ghClient)
 	tools.RenderCorpusHelpers(server, ghClient)
 	tools.RenderPneumaHelpers(server, ghClient)
 	tools.RenderTeamDocsIndex(server, v)

--- a/internal/cidr/cidr.go
+++ b/internal/cidr/cidr.go
@@ -97,7 +97,7 @@ func CollectSubnets(teams []*spec.Team) []spec.Subnet {
 // cidrAt computes the CIDR string at a given slot index for a range.
 func cidrAt(r cidrRange, index int) string {
 	step := uint32(1) << (32 - r.prefix)
-	ip := r.baseIP + uint32(index)*step
+	ip := r.baseIP + uint32(index)*step //nolint:gosec // index is bounded by maxCount (256)
 	return fmt.Sprintf("%s/%d", uint32ToIP(ip).String(), r.prefix)
 }
 
@@ -112,7 +112,11 @@ func slotIndex(r cidrRange, cidr string) int {
 	if ones != r.prefix {
 		return -1
 	}
-	addr := ipToUint32(ip.To4())
+	v4 := ip.To4()
+	if v4 == nil {
+		return -1
+	}
+	addr := ipToUint32(v4)
 	if addr < r.baseIP {
 		return -1
 	}
@@ -130,5 +134,5 @@ func ipToUint32(ip net.IP) uint32 {
 }
 
 func uint32ToIP(n uint32) net.IP {
-	return net.IPv4(byte(n>>24), byte(n>>16), byte(n>>8), byte(n))
+	return net.IPv4(byte(n>>24), byte(n>>16), byte(n>>8), byte(n)) //nolint:gosec // deliberate truncation to extract octets
 }

--- a/internal/cidr/cidr.go
+++ b/internal/cidr/cidr.go
@@ -1,0 +1,134 @@
+// Package cidr computes deterministic CIDR allocations for GKE subnets.
+//
+// The IPAM scheme allocates four coordinated CIDR ranges per GKE location
+// (slot). Each slot index maps to exactly one address in each range:
+//
+//   - Primary (ip_cidr_range):          10.60.0.0/20,  increment by /20
+//   - Pods (pod_ip_cidr_range):         10.0.0.0/15,   increment by /15
+//   - Services (services_ip_cidr_range): 10.61.224.0/20, increment by /20
+//   - Master (master_ipv4_cidr_block):  10.63.192.0/28, increment by /28
+package cidr
+
+import (
+	"fmt"
+	"net"
+	"sort"
+
+	"github.com/osinfra-io/pt-techne-mcp-server/internal/spec"
+)
+
+// Slot is one complete CIDR allocation across all four ranges.
+type Slot struct {
+	Index               int    `json:"slot"`
+	IPCidrRange         string `json:"ip_cidr_range"`
+	PodIPCidrRange      string `json:"pod_ip_cidr_range"`
+	ServicesIPCidrRange string `json:"services_ip_cidr_range"`
+	MasterIPv4CidrBlock string `json:"master_ipv4_cidr_block"`
+}
+
+// range defines one of the four CIDR progressions.
+type cidrRange struct {
+	baseIP uint32
+	prefix int
+}
+
+var (
+	primaryRange  = cidrRange{baseIP: ipToUint32(net.IPv4(10, 60, 0, 0)), prefix: 20}
+	podRange      = cidrRange{baseIP: ipToUint32(net.IPv4(10, 0, 0, 0)), prefix: 15}
+	servicesRange = cidrRange{baseIP: ipToUint32(net.IPv4(10, 61, 224, 0)), prefix: 20}
+	masterRange   = cidrRange{baseIP: ipToUint32(net.IPv4(10, 63, 192, 0)), prefix: 28}
+)
+
+// SlotFor computes the full CIDR allocation for the given slot index.
+func SlotFor(index int) Slot {
+	return Slot{
+		Index:               index,
+		IPCidrRange:         cidrAt(primaryRange, index),
+		PodIPCidrRange:      cidrAt(podRange, index),
+		ServicesIPCidrRange: cidrAt(servicesRange, index),
+		MasterIPv4CidrBlock: cidrAt(masterRange, index),
+	}
+}
+
+// SlotFromSubnet returns the slot index for an existing subnet by
+// reverse-mapping its primary CIDR. Returns -1 if the CIDR does not
+// align with the IPAM progression.
+func SlotFromSubnet(s spec.Subnet) int {
+	return slotIndex(primaryRange, s.IPCidrRange)
+}
+
+// NextAvailable returns the next count unallocated slots given the set
+// of existing subnets. It finds gaps in the allocation sequence and
+// returns the lowest available slot indices.
+func NextAvailable(existing []spec.Subnet, count int) []Slot {
+	used := make(map[int]bool)
+	for _, s := range existing {
+		if idx := slotIndex(primaryRange, s.IPCidrRange); idx >= 0 {
+			used[idx] = true
+		}
+	}
+
+	slots := make([]Slot, 0, count)
+	for i := 0; len(slots) < count; i++ {
+		if !used[i] {
+			slots = append(slots, SlotFor(i))
+		}
+	}
+	return slots
+}
+
+// CollectSubnets extracts all Subnet values from a set of parsed teams.
+func CollectSubnets(teams []*spec.Team) []spec.Subnet {
+	var out []spec.Subnet
+	for _, t := range teams {
+		if t.PlatformManagedProject == nil || t.PlatformManagedProject.KubernetesEngine == nil {
+			continue
+		}
+		for _, loc := range t.PlatformManagedProject.KubernetesEngine.Locations {
+			out = append(out, loc.Subnet)
+		}
+	}
+	sort.Slice(out, func(i, j int) bool {
+		return out[i].IPCidrRange < out[j].IPCidrRange
+	})
+	return out
+}
+
+// cidrAt computes the CIDR string at a given slot index for a range.
+func cidrAt(r cidrRange, index int) string {
+	step := uint32(1) << (32 - r.prefix)
+	ip := r.baseIP + uint32(index)*step
+	return fmt.Sprintf("%s/%d", uint32ToIP(ip).String(), r.prefix)
+}
+
+// slotIndex reverse-maps a CIDR string to its slot index in the given
+// range. Returns -1 if the CIDR does not parse or does not align.
+func slotIndex(r cidrRange, cidr string) int {
+	ip, network, err := net.ParseCIDR(cidr)
+	if err != nil {
+		return -1
+	}
+	ones, _ := network.Mask.Size()
+	if ones != r.prefix {
+		return -1
+	}
+	addr := ipToUint32(ip.To4())
+	if addr < r.baseIP {
+		return -1
+	}
+	step := uint32(1) << (32 - r.prefix)
+	offset := addr - r.baseIP
+	if offset%step != 0 {
+		return -1
+	}
+	return int(offset / step)
+}
+
+func ipToUint32(ip net.IP) uint32 {
+	ip = ip.To4()
+	return uint32(ip[0])<<24 | uint32(ip[1])<<16 | uint32(ip[2])<<8 | uint32(ip[3])
+}
+
+func uint32ToIP(n uint32) net.IP {
+	return net.IPv4(byte(n>>24), byte(n>>16), byte(n>>8), byte(n))
+}

--- a/internal/cidr/cidr_test.go
+++ b/internal/cidr/cidr_test.go
@@ -1,0 +1,133 @@
+package cidr
+
+import (
+	"testing"
+
+	"github.com/osinfra-io/pt-techne-mcp-server/internal/spec"
+)
+
+func TestSlotFor_KnownSlots(t *testing.T) {
+	// Verified against golden data from pt-pneuma.tfvars and pt-kryptos.tfvars.
+	tests := []struct {
+		slot    int
+		primary string
+		pod     string
+		svc     string
+		master  string
+	}{
+		{0, "10.60.0.0/20", "10.0.0.0/15", "10.61.224.0/20", "10.63.192.0/28"},
+		{1, "10.60.16.0/20", "10.2.0.0/15", "10.61.240.0/20", "10.63.192.16/28"},
+		{2, "10.60.32.0/20", "10.4.0.0/15", "10.62.0.0/20", "10.63.192.32/28"},
+		{3, "10.60.48.0/20", "10.6.0.0/15", "10.62.16.0/20", "10.63.192.48/28"},
+		{4, "10.60.64.0/20", "10.8.0.0/15", "10.62.32.0/20", "10.63.192.64/28"},
+		{5, "10.60.80.0/20", "10.10.0.0/15", "10.62.48.0/20", "10.63.192.80/28"},
+		{6, "10.60.96.0/20", "10.12.0.0/15", "10.62.64.0/20", "10.63.192.96/28"},
+		{7, "10.60.112.0/20", "10.14.0.0/15", "10.62.80.0/20", "10.63.192.112/28"},
+	}
+	for _, tt := range tests {
+		s := SlotFor(tt.slot)
+		if s.IPCidrRange != tt.primary {
+			t.Errorf("slot %d primary: got %s, want %s", tt.slot, s.IPCidrRange, tt.primary)
+		}
+		if s.PodIPCidrRange != tt.pod {
+			t.Errorf("slot %d pod: got %s, want %s", tt.slot, s.PodIPCidrRange, tt.pod)
+		}
+		if s.ServicesIPCidrRange != tt.svc {
+			t.Errorf("slot %d services: got %s, want %s", tt.slot, s.ServicesIPCidrRange, tt.svc)
+		}
+		if s.MasterIPv4CidrBlock != tt.master {
+			t.Errorf("slot %d master: got %s, want %s", tt.slot, s.MasterIPv4CidrBlock, tt.master)
+		}
+	}
+}
+
+func TestSlotFromSubnet(t *testing.T) {
+	tests := []struct {
+		subnet spec.Subnet
+		want   int
+	}{
+		{spec.Subnet{IPCidrRange: "10.60.0.0/20"}, 0},
+		{spec.Subnet{IPCidrRange: "10.60.16.0/20"}, 1},
+		{spec.Subnet{IPCidrRange: "10.60.112.0/20"}, 7},
+		{spec.Subnet{IPCidrRange: "invalid"}, -1},
+		{spec.Subnet{IPCidrRange: "10.60.0.0/24"}, -1}, // wrong prefix
+		{spec.Subnet{IPCidrRange: "10.60.1.0/20"}, -1}, // misaligned
+	}
+	for _, tt := range tests {
+		got := SlotFromSubnet(tt.subnet)
+		if got != tt.want {
+			t.Errorf("SlotFromSubnet(%q) = %d, want %d", tt.subnet.IPCidrRange, got, tt.want)
+		}
+	}
+}
+
+func TestNextAvailable_NoExisting(t *testing.T) {
+	slots := NextAvailable(nil, 3)
+	if len(slots) != 3 {
+		t.Fatalf("got %d slots, want 3", len(slots))
+	}
+	for i, s := range slots {
+		if s.Index != i {
+			t.Errorf("slot[%d].Index = %d, want %d", i, s.Index, i)
+		}
+	}
+}
+
+func TestNextAvailable_WithGaps(t *testing.T) {
+	// Slots 0, 1, 3 are allocated — next available should be 2, 4, 5.
+	existing := []spec.Subnet{
+		{IPCidrRange: "10.60.0.0/20"},  // slot 0
+		{IPCidrRange: "10.60.16.0/20"}, // slot 1
+		{IPCidrRange: "10.60.48.0/20"}, // slot 3
+	}
+	slots := NextAvailable(existing, 3)
+	if len(slots) != 3 {
+		t.Fatalf("got %d slots, want 3", len(slots))
+	}
+	wantIndices := []int{2, 4, 5}
+	for i, s := range slots {
+		if s.Index != wantIndices[i] {
+			t.Errorf("slot[%d].Index = %d, want %d", i, s.Index, wantIndices[i])
+		}
+	}
+}
+
+func TestNextAvailable_AllContiguous(t *testing.T) {
+	// Slots 0-7 allocated, next should be 8.
+	existing := make([]spec.Subnet, 8)
+	for i := range existing {
+		existing[i] = spec.Subnet{IPCidrRange: SlotFor(i).IPCidrRange}
+	}
+	slots := NextAvailable(existing, 1)
+	if len(slots) != 1 {
+		t.Fatalf("got %d slots, want 1", len(slots))
+	}
+	if slots[0].Index != 8 {
+		t.Errorf("got index %d, want 8", slots[0].Index)
+	}
+}
+
+func TestCollectSubnets(t *testing.T) {
+	teams := []*spec.Team{
+		{TeamKey: "pt-a"}, // no GKE
+		{
+			TeamKey: "pt-b",
+			PlatformManagedProject: &spec.PlatformManagedProject{
+				KubernetesEngine: &spec.KubernetesEngine{
+					Locations: map[string]spec.GKELocation{
+						"us-east1-b": {Subnet: spec.Subnet{IPCidrRange: "10.60.16.0/20"}},
+						"us-east1-c": {Subnet: spec.Subnet{IPCidrRange: "10.60.0.0/20"}},
+					},
+				},
+			},
+		},
+	}
+	subs := CollectSubnets(teams)
+	if len(subs) != 2 {
+		t.Fatalf("got %d subnets, want 2", len(subs))
+	}
+	// Sorted by ip_cidr_range.
+	if subs[0].IPCidrRange != "10.60.0.0/20" {
+		t.Errorf("first subnet = %s, want 10.60.0.0/20", subs[0].IPCidrRange)
+	}
+}

--- a/internal/tools/next_available_cidrs.go
+++ b/internal/tools/next_available_cidrs.go
@@ -1,0 +1,61 @@
+// MCP tool: next_available_cidrs.
+//
+// Computes the next N unallocated GKE subnet CIDR slots by scanning all
+// teams in pt-logos@main. Eliminates the need for agents to perform
+// multi-call CIDR arithmetic manually.
+package tools
+
+import (
+	"context"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+
+	"github.com/osinfra-io/pt-techne-mcp-server/internal/cidr"
+	gh "github.com/osinfra-io/pt-techne-mcp-server/internal/github"
+	"github.com/osinfra-io/pt-techne-mcp-server/internal/spec"
+)
+
+// NextAvailableCidrsInput is the input for next_available_cidrs.
+type NextAvailableCidrsInput struct {
+	Count int `json:"count" jsonschema:"number of CIDR slots to return (minimum 1)"`
+}
+
+// NextAvailableCidrsOutput is the structured result of next_available_cidrs.
+type NextAvailableCidrsOutput struct {
+	Slots []cidr.Slot `json:"slots"`
+}
+
+// NextAvailableCidrs registers the next_available_cidrs tool.
+// Requires GITHUB_TOKEN.
+func NextAvailableCidrs(s *mcp.Server, v *spec.Validator, c gh.Client) {
+	mcp.AddTool(s, &mcp.Tool{
+		Name:        "next_available_cidrs",
+		Description: "Compute the next N unallocated GKE subnet CIDR slots by scanning all team specs in osinfra-io/pt-logos@main. Returns deterministic CIDR allocations for ip_cidr_range, pod_ip_cidr_range, services_ip_cidr_range, and master_ipv4_cidr_block. Requires GITHUB_TOKEN.",
+		Annotations: &mcp.ToolAnnotations{
+			Title:        "Next available CIDRs",
+			ReadOnlyHint: true,
+		},
+	}, func(ctx context.Context, _ *mcp.CallToolRequest, in NextAvailableCidrsInput) (*mcp.CallToolResult, any, error) {
+		if c == nil {
+			return notConfigured("next_available_cidrs"), nil, nil
+		}
+		if in.Count < 1 {
+			return errResult(opError{Code: "invalid_input", Message: "count must be at least 1"}), nil, nil
+		}
+		ref, oe := resolveBaseRef(ctx, c)
+		if oe != nil {
+			return errResult(*oe), nil, nil
+		}
+		keys, oe := listTeamFiles(ctx, c, ref)
+		if oe != nil {
+			return errResult(*oe), nil, nil
+		}
+		teams, oe := fetchAllTeams(ctx, c, v, keys, ref)
+		if oe != nil {
+			return errResult(*oe), nil, nil
+		}
+		existing := cidr.CollectSubnets(teams)
+		slots := cidr.NextAvailable(existing, in.Count)
+		return nil, &NextAvailableCidrsOutput{Slots: slots}, nil
+	})
+}

--- a/internal/tools/next_available_cidrs.go
+++ b/internal/tools/next_available_cidrs.go
@@ -36,11 +36,12 @@ func NextAvailableCidrs(s *mcp.Server, v *spec.Validator, c gh.Client) {
 			ReadOnlyHint: true,
 		},
 	}, func(ctx context.Context, _ *mcp.CallToolRequest, in NextAvailableCidrsInput) (*mcp.CallToolResult, any, error) {
+		const maxCount = 256
 		if c == nil {
 			return notConfigured("next_available_cidrs"), nil, nil
 		}
-		if in.Count < 1 {
-			return errResult(opError{Code: "invalid_input", Message: "count must be at least 1"}), nil, nil
+		if in.Count < 1 || in.Count > maxCount {
+			return errResult(opError{Code: "invalid_input", Message: "count must be between 1 and 256"}), nil, nil
 		}
 		ref, oe := resolveBaseRef(ctx, c)
 		if oe != nil {

--- a/internal/tools/next_available_cidrs_test.go
+++ b/internal/tools/next_available_cidrs_test.go
@@ -1,0 +1,63 @@
+package tools_test
+
+import (
+	"testing"
+
+	"github.com/osinfra-io/pt-techne-mcp-server/internal/cidr"
+	"github.com/osinfra-io/pt-techne-mcp-server/internal/tools"
+)
+
+func TestNextAvailableCidrs_Goldens(t *testing.T) {
+	f := seedFakeFromGoldens(t)
+	h := newReadHarness(t, f)
+
+	res := h.call("next_available_cidrs", map[string]any{"count": 2})
+	var out tools.NextAvailableCidrsOutput
+	decodeStruct(t, res, &out)
+
+	if len(out.Slots) != 2 {
+		t.Fatalf("expected 2 slots, got %d: %+v", len(out.Slots), out.Slots)
+	}
+	// Golden data has 8 locations (slots 0-7), so next should be 8 and 9.
+	if out.Slots[0].Index != 8 {
+		t.Errorf("first slot index = %d, want 8", out.Slots[0].Index)
+	}
+	if out.Slots[1].Index != 9 {
+		t.Errorf("second slot index = %d, want 9", out.Slots[1].Index)
+	}
+	// Verify the CIDRs match SlotFor computation.
+	want8 := cidr.SlotFor(8)
+	if out.Slots[0].IPCidrRange != want8.IPCidrRange {
+		t.Errorf("slot 8 primary = %s, want %s", out.Slots[0].IPCidrRange, want8.IPCidrRange)
+	}
+	if out.Slots[0].PodIPCidrRange != want8.PodIPCidrRange {
+		t.Errorf("slot 8 pod = %s, want %s", out.Slots[0].PodIPCidrRange, want8.PodIPCidrRange)
+	}
+}
+
+func TestNextAvailableCidrs_CountOne(t *testing.T) {
+	f := seedFakeFromGoldens(t)
+	h := newReadHarness(t, f)
+
+	res := h.call("next_available_cidrs", map[string]any{"count": 1})
+	var out tools.NextAvailableCidrsOutput
+	decodeStruct(t, res, &out)
+
+	if len(out.Slots) != 1 {
+		t.Fatalf("expected 1 slot, got %d", len(out.Slots))
+	}
+	if out.Slots[0].Index != 8 {
+		t.Errorf("slot index = %d, want 8", out.Slots[0].Index)
+	}
+}
+
+func TestNextAvailableCidrs_InvalidCount(t *testing.T) {
+	f := seedFakeFromGoldens(t)
+	h := newReadHarness(t, f)
+
+	res := h.call("next_available_cidrs", map[string]any{"count": 0})
+	body := decodeError(t, res)
+	if body["code"] != "invalid_input" {
+		t.Fatalf("expected invalid_input, got %+v", body)
+	}
+}

--- a/internal/tools/next_available_cidrs_test.go
+++ b/internal/tools/next_available_cidrs_test.go
@@ -55,9 +55,17 @@ func TestNextAvailableCidrs_InvalidCount(t *testing.T) {
 	f := seedFakeFromGoldens(t)
 	h := newReadHarness(t, f)
 
+	// count = 0
 	res := h.call("next_available_cidrs", map[string]any{"count": 0})
 	body := decodeError(t, res)
 	if body["code"] != "invalid_input" {
 		t.Fatalf("expected invalid_input, got %+v", body)
+	}
+
+	// count too large
+	res = h.call("next_available_cidrs", map[string]any{"count": 999})
+	body = decodeError(t, res)
+	if body["code"] != "invalid_input" {
+		t.Fatalf("expected invalid_input for large count, got %+v", body)
 	}
 }

--- a/internal/tools/read_tools_test.go
+++ b/internal/tools/read_tools_test.go
@@ -35,6 +35,7 @@ func newReadHarness(t *testing.T, c gh.Client) *readToolHarness {
 	tools.GetTeam(server, v, c)
 	tools.LookupUser(server, v, c)
 	tools.FindRepo(server, v, c)
+	tools.NextAvailableCidrs(server, v, c)
 
 	ct, st := mcp.NewInMemoryTransports()
 	ctx := context.Background()
@@ -125,6 +126,7 @@ func TestReadTools_NotConfigured(t *testing.T) {
 		{"get_team", map[string]any{"team_key": "pt-arche"}},
 		{"lookup_user", map[string]any{"github_username": "brettcurtis"}},
 		{"find_repo", map[string]any{"name": "pt-arche-core-helpers"}},
+		{"next_available_cidrs", map[string]any{"count": 1}},
 	} {
 		t.Run(c.name, func(t *testing.T) {
 			res := h.call(c.name, c.args)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new MCP tool, next_available_cidrs, to compute the next available CIDR slots for GKE subnets with deterministic allocation across primary, pod, service, and master ranges and input validation.
* **Tests**
  * Added unit and integration tests covering CIDR allocation logic, tool behavior, input validation, and error cases.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/osinfra-io/pt-techne-mcp-server/pull/29?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->