### PR TITLE
Add cosign keyless signing to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,7 @@ on:
 
 permissions:
   contents: write
+  id-token: write
   packages: write
 
 jobs:
@@ -49,15 +50,29 @@ jobs:
     name: "Release"
     needs: binaries
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      id-token: write
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+
+      - name: Install cosign
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6  # v4.1.2
 
       - name: Download artifacts
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
         with:
           path: dist
           merge-multiple: true
+
+      - name: Sign binaries
+        run: |
+          for bin in dist/pt-techne-mcp-server-*; do
+            cosign sign-blob --yes "$bin" \
+              --output-signature "${bin}.sig" \
+              --output-certificate "${bin}.cert"
+          done
 
       - name: Create release
         env:
@@ -75,10 +90,14 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      id-token: write
       packages: write
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+
+      - name: Install cosign
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6  # v4.1.2
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a  # v4.0.0
@@ -94,6 +113,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push image
+        id: push
         uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf  # v7.2.0
         with:
           context: .
@@ -105,3 +125,10 @@ jobs:
           tags: |
             ghcr.io/${{ github.repository_owner }}/pt-techne-mcp-server:${{ github.ref_name }}
             ghcr.io/${{ github.repository_owner }}/pt-techne-mcp-server:latest
+
+      - name: Sign image
+        env:
+          DIGEST: ${{ steps.push.outputs.digest }}
+        run: |
+          cosign sign --yes \
+            "ghcr.io/${{ github.repository_owner }}/pt-techne-mcp-server@${DIGEST}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,6 @@ on:
 
 permissions:
   contents: write
-  id-token: write
   packages: write
 
 jobs:

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ Release artifacts are signed with [cosign keyless](https://docs.sigstore.dev/cos
 
 ```sh
 cosign verify ghcr.io/osinfra-io/pt-techne-mcp-server:<tag> \
-  --certificate-identity-regexp='https://github.com/osinfra-io/pt-techne-mcp-server' \
+  --certificate-identity-regexp='https://github.com/osinfra-io/pt-techne-mcp-server/.github/workflows/release.yml@refs/tags/.*' \
   --certificate-oidc-issuer='https://token.actions.githubusercontent.com'
 ```
 
@@ -89,7 +89,7 @@ gh release download --repo osinfra-io/pt-techne-mcp-server --pattern '*linux-amd
 cosign verify-blob pt-techne-mcp-server-linux-amd64 \
   --signature pt-techne-mcp-server-linux-amd64.sig \
   --certificate pt-techne-mcp-server-linux-amd64.cert \
-  --certificate-identity-regexp='https://github.com/osinfra-io/pt-techne-mcp-server' \
+  --certificate-identity-regexp='https://github.com/osinfra-io/pt-techne-mcp-server/.github/workflows/release.yml@refs/tags/.*' \
   --certificate-oidc-issuer='https://token.actions.githubusercontent.com'
 ```
 

--- a/README.md
+++ b/README.md
@@ -69,6 +69,30 @@ go install github.com/osinfra-io/pt-techne-mcp-server/cmd/pt-techne-mcp-server@l
 }
 ```
 
+### Verification
+
+Release artifacts are signed with [cosign keyless](https://docs.sigstore.dev/cosign/signing/overview/) (Sigstore OIDC). Install [cosign](https://docs.sigstore.dev/cosign/system_config/installation/) to verify.
+
+**Container image:**
+
+```sh
+cosign verify ghcr.io/osinfra-io/pt-techne-mcp-server:<tag> \
+  --certificate-identity-regexp='https://github.com/osinfra-io/pt-techne-mcp-server' \
+  --certificate-oidc-issuer='https://token.actions.githubusercontent.com'
+```
+
+**Binary:**
+
+```sh
+gh release download --repo osinfra-io/pt-techne-mcp-server --pattern '*linux-amd64*'
+
+cosign verify-blob pt-techne-mcp-server-linux-amd64 \
+  --signature pt-techne-mcp-server-linux-amd64.sig \
+  --certificate pt-techne-mcp-server-linux-amd64.cert \
+  --certificate-identity-regexp='https://github.com/osinfra-io/pt-techne-mcp-server' \
+  --certificate-oidc-issuer='https://token.actions.githubusercontent.com'
+```
+
 ### Configuration
 
 Set `GITHUB_TOKEN` with access to `osinfra-io/pt-logos`, `osinfra-io/pt-corpus`, `osinfra-io/pt-pneuma`, and `osinfra-io/pt-ekklesia-docs`. Without it, GitHub-backed tools return `not_configured`; offline tools (`validate_team_spec`, `render_team_tfvars`, `render_team_docs_index`, `render_sidebar_patch`) still work.


### PR DESCRIPTION
Sign the GHCR container image and release binaries using cosign keyless (Sigstore OIDC). The GitHub Actions runner's identity token is used for signing — no secrets or key management required.

## Changes

- **Image job:** Install cosign, sign the image by digest after push
- **Release job:** Install cosign, sign each binary blob (`.sig` + `.cert`) before uploading to the release
- **README:** Added a "Verification" section showing how to verify both artifacts

## Permissions

Added `id-token: write` to both jobs (required for the OIDC token request to Sigstore's Fulcio CA).

Closes #1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Release binaries and container images are now cryptographically signed using keyless OIDC signing; signatures and accompanying certificates are produced alongside released artifacts for stronger authenticity.

* **Documentation**
  * Added a Verification section with step-by-step instructions to validate downloaded binaries and GHCR container images using the provided signatures and certificates.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/osinfra-io/pt-techne-mcp-server/pull/30?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->