### PR TITLE
Replace deprecated cosign flags with --bundle

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,8 +69,7 @@ jobs:
         run: |
           for bin in dist/pt-techne-mcp-server-*; do
             cosign sign-blob --yes "$bin" \
-              --output-signature "${bin}.sig" \
-              --output-certificate "${bin}.cert"
+              --bundle "${bin}.bundle"
           done
 
       - name: Create release


### PR DESCRIPTION
The `--output-signature` and `--output-certificate` flags are deprecated in the new cosign bundle format. When ignored, the bundle output path is empty, causing:

```
Error: signing dist/pt-techne-mcp-server-linux-amd64: create bundle file: open : no such file or directory
```

This replaces both flags with `--bundle "${bin}.bundle"`, which writes a single bundle file containing both the signature and certificate.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the binary signing process in the release workflow to use bundled artifact format during the release build.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/osinfra-io/pt-techne-mcp-server/pull/31?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->