### PR TITLE
Fix doc drift: next_available_cidrs in tool tables, Dependabot badge, instructions path

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -4,7 +4,7 @@ This file applies to every change in this repo. Read it together with the
 platform- and techne-team instructions, both of which are loaded by Copilot
 automatically:
 
-- `pt-ai-context/.github/instructions/team.instructions.md` — platform-wide
+- `pt-ai-context/.github/instructions/platform-group.instructions.md` — platform-wide
   conventions (commits, PRs, labels, full-SHA action pins, "keep it simple").
 - `techne/pt-techne-ai-context/.github/instructions/techne-team.instructions.md` —
   techne team conventions.
@@ -28,6 +28,7 @@ GHCR container image.
 | `list_teams` | List all teams from pt-logos | No |
 | `get_team` | Get a single team's spec | No |
 | `find_repo` | Find repository owner/team | No |
+| `next_available_cidrs` | Compute next N unallocated GKE subnet CIDR slots | No |
 | `lookup_user` | Look up user across GitHub + Datadog | No |
 | `open_team_pr` | Open/update a PR on pt-logos (idempotent) | Yes |
 | `open_team_docs_pr` | Open/update a PR on pt-ekklesia-docs | Yes |

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Techne MCP Server
 
 [![Tests](https://img.shields.io/github/actions/workflow/status/osinfra-io/pt-techne-mcp-server/go-test.yml?style=for-the-badge&logo=go&color=00ADD8&label=Tests)](https://github.com/osinfra-io/pt-techne-mcp-server/actions/workflows/go-test.yml)
+[![Dependabot](https://img.shields.io/github/actions/workflow/status/osinfra-io/pt-techne-mcp-server/dependabot.yml?style=for-the-badge&logo=github&color=2088FF&label=Dependabot)](https://github.com/osinfra-io/pt-techne-mcp-server/actions/workflows/dependabot.yml)
 
 Model Context Protocol (MCP) server providing platform context and tools to AI assistants. Exposes deterministic, typed tools so platform agents call a tested renderer instead of writing HCL by hand.
 
@@ -109,6 +110,7 @@ For local development, `gh auth token` is the simplest option. See [docs/configu
 | `get_team` | Get a single team's spec and docs pages |
 | `lookup_user` | Find every team/role where a user appears |
 | `find_repo` | Find which team(s) own a repository |
+| `next_available_cidrs` | Compute the next N unallocated GKE subnet CIDR slots |
 | `render_corpus_helpers` | Insert a workspace into pt-corpus `helpers.tofu` |
 | `render_pneuma_helpers` | Insert a workspace into pt-pneuma `helpers.tofu` |
 | `render_team_docs_index` | Render a team's docs index page |


### PR DESCRIPTION
## What

Documentation accuracy fixes found during a review of the MCP server and the Nomos agent contract. No code changes.

- **`README.md`** — the Tools table listed 12 of the 13 registered tools; added the missing `next_available_cidrs` row (registered in `cmd/pt-techne-mcp-server/main.go`).
- **`README.md`** — added the Dependabot badge (the repo has a `dependabot.yml` workflow; platform badge conventions call for it).
- **`.github/copilot-instructions.md`** — the tools table was also missing `next_available_cidrs`; added it.
- **`.github/copilot-instructions.md`** — corrected a stale instructions path (`pt-ai-context/.github/instructions/team.instructions.md` → `platform-group.instructions.md`).

## Verification

- `pre-commit run -a` passes (check-yaml, end-of-files, trailing-whitespace, check-symlinks, golangci-lint-full, schemadoc, go-test).
- `go build ./...`, `go vet ./...`, `go test ./...` all green.

The agent↔server contract was verified end to end as part of the review: all 13 registered tool names and their input parameters match the references in `pt-techne-agents` `techne-nomos.agent.md`.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated developer documentation with reference to platform-group instructions.
  * Added `next_available_cidrs` tool to the available MCP tools list for computing unallocated GKE subnet CIDR slots.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/osinfra-io/pt-techne-mcp-server/pull/38?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->