### PR TITLE
Lint nits: silence schemadoc gosec false positives, drop redundant loop aliasing

### DIFF
--- a/internal/schemadoc/main.go
+++ b/internal/schemadoc/main.go
@@ -33,7 +33,7 @@ func main() {
 		fmt.Fprintln(os.Stderr, "usage: schemadoc <schema.json> <out.md>")
 		os.Exit(2)
 	}
-	data, err := os.ReadFile(os.Args[1])
+	data, err := os.ReadFile(os.Args[1]) //nolint:gosec // dev-only CLI generator; path is its own argv, not untrusted input
 	if err != nil {
 		die(fmt.Errorf("read schema %q: %w", os.Args[1], err))
 	}
@@ -66,7 +66,7 @@ func main() {
 
 	out := strings.TrimRight(b.String(), "\n") + "\n"
 
-	if err := os.WriteFile(os.Args[2], []byte(out), 0o600); err != nil {
+	if err := os.WriteFile(os.Args[2], []byte(out), 0o600); err != nil { //nolint:gosec // dev-only CLI generator; path is its own argv, not untrusted input
 		die(fmt.Errorf("write markdown %q: %w", os.Args[2], err))
 	}
 }

--- a/internal/tools/team_source.go
+++ b/internal/tools/team_source.go
@@ -117,7 +117,6 @@ func fetchAllTeams(ctx context.Context, c gh.Client, v *spec.Validator, keys []s
 	var mu sync.Mutex
 	var firstOpErr *opError
 	for i, k := range keys {
-		i, k := i, k
 		g.Go(func() error {
 			t, oe := fetchTeam(gctx, c, v, k, ref)
 			if oe != nil {


### PR DESCRIPTION
## What

Two small code-quality fixes found during the agent/MCP review. No behavior change.

- **`internal/schemadoc/main.go`** — newer `golangci-lint` (gosec G703 "path traversal via taint analysis") flags the two `os.ReadFile`/`os.WriteFile` calls that take the generator's own `os.Args` paths. `schemadoc` is a dev-only CLI that turns the embedded schema into `docs/schema.md`; the paths are its own argv, not untrusted input. Added targeted `//nolint:gosec` directives with justification so future linter upgrades stay clean. (The CI-pinned `golangci-lint` v2.2.1 predates G703, so CI was already green.)
- **`internal/tools/team_source.go`** — removed the redundant `i, k := i, k` loop-variable aliasing; loop variables are per-iteration since Go 1.22 and `go.mod` targets 1.26.

## Verification

`pre-commit run -a` green (golangci-lint-full, schemadoc, go-test); `go build`/`go test ./...` pass. Verified the gosec findings are gone under a newer local `golangci-lint` (v2.12).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Applied enhanced code quality standards with improved linting configuration for internal file operations.

* **Refactor**
  * Optimized concurrent data processing logic by refining variable scoping in asynchronous operations to improve system reliability and execution correctness.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/osinfra-io/pt-techne-mcp-server/pull/39?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->