### PR TITLE
Make display_name_comment required in schema

### DIFF
--- a/docs/schema.md
+++ b/docs/schema.md
@@ -21,10 +21,10 @@ Team display name. Title Case; spaces and the lowercase word "and" are allowed.
 
 ## `display_name_comment`
 
-Optional inline comment rendered after display_name. Used for the team etymology blurb. Also used as the `description` frontmatter on the team's docs index page (rendered by pt-techne-mcp-server/render_team_docs_index); that tool requires this field.
+Inline comment rendered after display_name in the tfvars file. Used for the team etymology blurb. Also used as the `description` frontmatter on the team's docs index page; render_team_docs_index and open_team_docs_pr require this field to be non-empty — an empty string will produce a docs_input_invalid error.
 
 - **type:** `string`
-- **required:** false
+- **required:** true
 
 ## `enable_google_project`
 

--- a/internal/spec/schema_embed.json
+++ b/internal/spec/schema_embed.json
@@ -9,6 +9,7 @@
     "team_key",
     "datadog_team_memberships",
     "display_name",
+    "display_name_comment",
     "github_parent_team_memberships",
     "google_basic_groups_memberships",
     "team_type"
@@ -35,8 +36,9 @@
       "pattern": "^[A-Z][A-Za-z]*( (and|[A-Z][A-Za-z]*))*$"
     },
     "display_name_comment": {
-      "description": "Optional inline comment rendered after display_name. Used for the team etymology blurb. Also used as the `description` frontmatter on the team's docs index page (rendered by pt-techne-mcp-server/render_team_docs_index); that tool requires this field.",
-      "type": "string"
+      "description": "Inline comment rendered after display_name in the tfvars file. Used for the team etymology blurb. Also used as the `description` frontmatter on the team's docs index page; render_team_docs_index and open_team_docs_pr require this field to be non-empty — an empty string will produce a docs_input_invalid error.",
+      "type": "string",
+      "minLength": 1
     },
     "enable_google_project": {
       "description": "Enable a Google Cloud project for this team in the team's environment folder via pt-corpus. Default: false.",

--- a/internal/spec/validate_test.go
+++ b/internal/spec/validate_test.go
@@ -14,6 +14,7 @@ func minimalValid() string {
 		"team_key": "pt-example",
 		"datadog_team_memberships": {"admins": ["a@b.com"], "members": []},
 		"display_name": "Example",
+		"display_name_comment": "An example team used in tests.",
 		"github_parent_team_memberships": {"maintainers": ["x"], "members": []},
 		"google_basic_groups_memberships": {
 			"admin":  {"managers": [], "members": [], "owners": ["a@b.com"]},

--- a/internal/tools/docs_render_test.go
+++ b/internal/tools/docs_render_test.go
@@ -79,15 +79,17 @@ func TestRenderTeamDocsIndex_MissingDescription(t *testing.T) {
 	if !res.IsError {
 		t.Fatalf("expected error")
 	}
-	var e map[string]any
+	// display_name_comment is now required by the schema, so the error is a
+	// schema validation failure (not docs_input_invalid).
+	var out map[string]any
 	for _, c := range res.Content {
 		if tc, ok := c.(*mcp.TextContent); ok {
-			_ = json.Unmarshal([]byte(tc.Text), &e)
+			_ = json.Unmarshal([]byte(tc.Text), &out)
 			break
 		}
 	}
-	if e["code"] != "docs_input_invalid" {
-		t.Errorf("code=%v want docs_input_invalid", e["code"])
+	if out["valid"] != false {
+		t.Errorf("expected valid=false, got: %v", out)
 	}
 }
 

--- a/internal/tools/open_team_docs_pr.go
+++ b/internal/tools/open_team_docs_pr.go
@@ -51,7 +51,7 @@ const sidebarsPath = "sidebars.js"
 func OpenTeamDocsPR(s *mcp.Server, v *spec.Validator, c gh.Client) {
 	mcp.AddTool(s, &mcp.Tool{
 		Name:        "open_team_docs_pr",
-		Description: "Validate, render index.md, patch sidebars.js, and open-or-update a PR on osinfra-io/pt-ekklesia-docs for the given team spec. Idempotent. Requires GITHUB_TOKEN with write access to pt-ekklesia-docs.",
+		Description: "Validate, render index.md, patch sidebars.js, and open-or-update a PR on osinfra-io/pt-ekklesia-docs for the given team spec. Idempotent. display_name_comment must be non-empty in the spec (it becomes the page description and lede paragraph). Requires GITHUB_TOKEN with write access to pt-ekklesia-docs.",
 		Annotations: &mcp.ToolAnnotations{
 			Title:        "Open team docs PR",
 			ReadOnlyHint: false,

--- a/internal/tools/render_team_docs_index.go
+++ b/internal/tools/render_team_docs_index.go
@@ -33,7 +33,7 @@ type RenderTeamDocsIndexOutput struct {
 func RenderTeamDocsIndex(s *mcp.Server, v *spec.Validator) {
 	mcp.AddTool(s, &mcp.Tool{
 		Name:        "render_team_docs_index",
-		Description: "Validate then render a team spec to the deterministic docs/<section>/<team>/index.md page for osinfra-io/pt-ekklesia-docs. Returns {path, content}. On schema failure returns ValidateOutput; on docs-specific input failure returns docs_input_invalid.",
+		Description: "Validate then render a team spec to the deterministic docs/<section>/<team>/index.md page for osinfra-io/pt-ekklesia-docs. Returns {path, content}. On schema failure returns ValidateOutput; on docs-specific input failure returns docs_input_invalid. display_name_comment must be non-empty in the spec (it becomes the page description and lede paragraph).",
 		Annotations: &mcp.ToolAnnotations{
 			Title:        "Render team docs index",
 			ReadOnlyHint: true,


### PR DESCRIPTION
Closes #32

## Problem

`open_team_docs_pr` fails with `docs_input_invalid` when `display_name_comment` is absent. The field was listed as `required: false` in `docs/schema.md`, so agents skipped it and only discovered the requirement after a failed call.

## Fix

- Add `display_name_comment` to the top-level `required` array in `team.schema.json` — `validate_team_spec` now catches a missing value immediately, before any PR is opened
- Update both `render_team_docs_index` and `open_team_docs_pr` tool descriptions to call out the requirement explicitly
- Update `minimalValid()` test fixture and `TestRenderTeamDocsIndex_MissingDescription` to reflect the new behaviour (schema error instead of `docs_input_invalid`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified that the team "display name comment" field is now required and must be non-empty for team documentation.
  * Specified this field is used as the docs page description (frontmatter) and as the leading paragraph on the team docs index.
  * Documented that omission now triggers a structured docs validation failure and described the expected failure response.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->