### PR TITLE
Rename GITHUB_TOKEN to NOMOS_GITHUB_TOKEN

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -33,7 +33,7 @@ GHCR container image.
 | `open_team_pr` | Open/update a PR on pt-logos (idempotent) | Yes |
 | `open_team_docs_pr` | Open/update a PR on pt-ekklesia-docs | Yes |
 
-All tools require `GITHUB_TOKEN`. Without it, read tools return
+All tools require `NOMOS_GITHUB_TOKEN`. Without it, read tools return
 `not_configured`; write tools do the same.
 
 ## Hard rules
@@ -57,7 +57,7 @@ The allowed list is fixed. Adding a dependency requires explicit discussion.
 - `github.com/modelcontextprotocol/go-sdk` — MCP transport + tool SDK
 - `github.com/santhosh-tekuri/jsonschema/v6` — JSON Schema validation
 - `github.com/google/go-github/v68` — GitHub API client
-- `golang.org/x/oauth2` — static `TokenSource` for `GITHUB_TOKEN`
+- `golang.org/x/oauth2` — static `TokenSource` for `NOMOS_GITHUB_TOKEN`
 - `github.com/hashicorp/hcl/v2` + `github.com/zclconf/go-cty` — HCL2
   round-trip parser for `.tfvars`
 - `golang.org/x/sync` — `errgroup` for bounded concurrent fetches

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,10 +2,10 @@
 # https://docs.docker.com/build/building/multi-stage/
 #
 # Runtime configuration (env vars; all optional):
-#   GITHUB_TOKEN — enables open_team_pr (validate/render work without it).
-#                  Any GH token works: PAT, gh auth token output, or an App
-#                  installation token (e.g. from actions/create-github-app-token).
-#                  See README "Configuration" for required permissions.
+#   NOMOS_GITHUB_TOKEN — enables open_team_pr (validate/render work without it).
+#                        Any GH token works: PAT, gh auth token output, or an App
+#                        installation token (e.g. from actions/create-github-app-token).
+#                        See README "Configuration" for required permissions.
 
 FROM golang:1.26.4-alpine AS build
 WORKDIR /src

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Add this entry to your MCP client config (e.g. `.copilot/mcp.json`, `mcp.json`):
       "command": "docker",
       "args": [
         "run", "-i", "--rm",
-        "-e", "GITHUB_TOKEN",
+        "-e", "NOMOS_GITHUB_TOKEN",
         "ghcr.io/osinfra-io/pt-techne-mcp-server:latest"
       ]
     }
@@ -44,7 +44,7 @@ Then configure your MCP client:
     "pt-techne-mcp-server": {
       "command": "/path/to/pt-techne-mcp-server-linux-amd64",
       "env": {
-        "GITHUB_TOKEN": "<YOUR_TOKEN>"
+        "NOMOS_GITHUB_TOKEN": "<YOUR_TOKEN>"
       }
     }
   }
@@ -63,7 +63,7 @@ go install github.com/osinfra-io/pt-techne-mcp-server/cmd/pt-techne-mcp-server@l
     "pt-techne-mcp-server": {
       "command": "pt-techne-mcp-server",
       "env": {
-        "GITHUB_TOKEN": "<YOUR_TOKEN>"
+        "NOMOS_GITHUB_TOKEN": "<YOUR_TOKEN>"
       }
     }
   }
@@ -95,7 +95,7 @@ cosign verify-blob pt-techne-mcp-server-linux-amd64 \
 
 ### Configuration
 
-Set `GITHUB_TOKEN` with access to `osinfra-io/pt-logos`, `osinfra-io/pt-corpus`, `osinfra-io/pt-pneuma`, and `osinfra-io/pt-ekklesia-docs`. Without it, GitHub-backed tools return `not_configured`; offline tools (`validate_team_spec`, `render_team_tfvars`, `render_team_docs_index`, `render_sidebar_patch`) still work.
+Set `NOMOS_GITHUB_TOKEN` with access to `osinfra-io/pt-logos`, `osinfra-io/pt-corpus`, `osinfra-io/pt-pneuma`, and `osinfra-io/pt-ekklesia-docs`. Without it, GitHub-backed tools return `not_configured`; offline tools (`validate_team_spec`, `render_team_tfvars`, `render_team_docs_index`, `render_sidebar_patch`) still work.
 
 For local development, `gh auth token` is the simplest option. See [docs/configuration.md](docs/configuration.md) for full details on token scopes, sources, and operational error codes.
 

--- a/cmd/pt-techne-mcp-server/main.go
+++ b/cmd/pt-techne-mcp-server/main.go
@@ -5,19 +5,19 @@
 //   - validate_team_spec      — validate a team spec against schema/team.schema.json
 //   - render_team_tfvars      — render a validated spec to canonical pt-logos tfvars
 //   - open_team_pr            — open or update a PR on osinfra-io/pt-logos with the
-//     rendered tfvars (requires GITHUB_TOKEN)
-//   - list_teams              — summary index of every team in pt-logos@main (requires GITHUB_TOKEN)
-//   - get_team                — parsed spec + docs_pages for one team (requires GITHUB_TOKEN)
-//   - lookup_user             — every team and role a user appears in (requires GITHUB_TOKEN)
-//   - find_repo               — which team owns a github repository (requires GITHUB_TOKEN)
-//   - next_available_cidrs    — compute next N unallocated GKE subnet CIDR slots (requires GITHUB_TOKEN)
+//     rendered tfvars (requires NOMOS_GITHUB_TOKEN)
+//   - list_teams              — summary index of every team in pt-logos@main (requires NOMOS_GITHUB_TOKEN)
+//   - get_team                — parsed spec + docs_pages for one team (requires NOMOS_GITHUB_TOKEN)
+//   - lookup_user             — every team and role a user appears in (requires NOMOS_GITHUB_TOKEN)
+//   - find_repo               — which team owns a github repository (requires NOMOS_GITHUB_TOKEN)
+//   - next_available_cidrs    — compute next N unallocated GKE subnet CIDR slots (requires NOMOS_GITHUB_TOKEN)
 //   - render_corpus_helpers   — insert a team's main-production workspace into
-//     osinfra-io/pt-corpus/helpers.tofu (requires GITHUB_TOKEN)
-//   - render_pneuma_helpers   — same for osinfra-io/pt-pneuma/helpers.tofu (requires GITHUB_TOKEN)
+//     osinfra-io/pt-corpus/helpers.tofu (requires NOMOS_GITHUB_TOKEN)
+//   - render_pneuma_helpers   — same for osinfra-io/pt-pneuma/helpers.tofu (requires NOMOS_GITHUB_TOKEN)
 //   - render_team_docs_index  — render the team's docs/<section>/<team>/index.md page
 //   - render_sidebar_patch    — patch a supplied pt-ekklesia-docs sidebars.js
 //   - open_team_docs_pr       — open or update a PR on osinfra-io/pt-ekklesia-docs
-//     with the rendered docs index + sidebars patch (requires GITHUB_TOKEN)
+//     with the rendered docs index + sidebars patch (requires NOMOS_GITHUB_TOKEN)
 //
 // Transport is stdio only.
 package main
@@ -46,7 +46,7 @@ func main() {
 	}
 
 	var ghClient gh.Client
-	if token := os.Getenv("GITHUB_TOKEN"); token != "" {
+	if token := os.Getenv("NOMOS_GITHUB_TOKEN"); token != "" {
 		ghClient = gh.New(ctx, token)
 	}
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,6 +1,6 @@
 # Configuration
 
-## `GITHUB_TOKEN`
+## `NOMOS_GITHUB_TOKEN`
 
 Required by `open_team_pr`, the four pt-logos read tools (`list_teams`, `get_team`, `lookup_user`, `find_repo`), the two helpers renderers (`render_corpus_helpers`, `render_pneuma_helpers`), and `open_team_docs_pr`. Without it the server still serves `validate_team_spec`, `render_team_tfvars`, `render_team_docs_index`, and `render_sidebar_patch`; the GitHub-backed tools return a structured `not_configured` error.
 
@@ -12,14 +12,14 @@ The token must be scoped to **`osinfra-io/pt-logos`**, **`osinfra-io/pt-corpus`*
 
 ### Token sources
 
-- **GitHub App** (recommended for non-interactive deployments). In the App's settings, repository permissions → Contents: Read and write, Pull requests: Read and write; repository access → Only select repositories → `osinfra-io/pt-logos`, `osinfra-io/pt-corpus`, `osinfra-io/pt-pneuma`, `osinfra-io/pt-ekklesia-docs`. Mint installation tokens with [`actions/create-github-app-token`](https://github.com/actions/create-github-app-token) and pass the result as `GITHUB_TOKEN`.
+- **GitHub App** (recommended for non-interactive deployments). In the App's settings, repository permissions → Contents: Read and write, Pull requests: Read and write; repository access → Only select repositories → `osinfra-io/pt-logos`, `osinfra-io/pt-corpus`, `osinfra-io/pt-pneuma`, `osinfra-io/pt-ekklesia-docs`. Mint installation tokens with [`actions/create-github-app-token`](https://github.com/actions/create-github-app-token) and pass the result as `NOMOS_GITHUB_TOKEN`.
 - **Fine-grained PAT** (local development). At <https://github.com/settings/personal-access-tokens>, resource owner `osinfra-io`; repository access → Only select repositories → the four repos above; repository permissions → Contents: Read and write, Pull requests: Read and write.
 - **`gh auth token`** works for local development as long as your account can push to a branch on `pt-logos` and `pt-ekklesia-docs` and open PRs against them, and read `pt-corpus` and `pt-pneuma`.
 - **Classic PAT** is not recommended — the closest equivalent (`repo` scope) grants far more than the tool needs.
 
 ### Rotation
 
-There is nothing to rotate inside the server — restart with a fresh `GITHUB_TOKEN`. Whatever produced the previous token is responsible for revoking it.
+There is nothing to rotate inside the server — restart with a fresh `NOMOS_GITHUB_TOKEN`. Whatever produced the previous token is responsible for revoking it.
 
 ## Operational errors
 
@@ -31,7 +31,7 @@ All tools return structured MCP `isError` results:
 
   | `code` | `retryable` | Meaning |
   |---|---|---|
-  | `not_configured` | false | `GITHUB_TOKEN` was empty at startup. Set it and restart. |
+  | `not_configured` | false | `NOMOS_GITHUB_TOKEN` was empty at startup. Set it and restart. |
   | `not_found` | false | `get_team` was called with an unknown `team_key`. |
   | `invalid_input` | false | `lookup_user` was called with neither or both of `github_username` and `email`; or `render_corpus_helpers`/`render_pneuma_helpers` was called with a `team_key` that does not match the team-spec regex; or `render_sidebar_patch` was called without `current_sidebars_js`; or `find_repo` was called with an empty `name`. |
   | `docs_input_invalid` | false | `render_team_docs_index`, `render_sidebar_patch`, or `open_team_docs_pr` was given a spec the docs renderer can't use (missing `display_name_comment`, unknown `team_type`, `team_key` without a recognised prefix). |

--- a/internal/tools/find_repo.go
+++ b/internal/tools/find_repo.go
@@ -28,11 +28,11 @@ type FindRepoOutput struct {
 	Matches []FindRepoMatch `json:"matches"`
 }
 
-// FindRepo registers the find_repo tool. Requires GITHUB_TOKEN.
+// FindRepo registers the find_repo tool. Requires NOMOS_GITHUB_TOKEN.
 func FindRepo(s *mcp.Server, v *spec.Validator, c gh.Client) {
 	mcp.AddTool(s, &mcp.Tool{
 		Name:        "find_repo",
-		Description: "Find which team(s) own a github repository. Walks every team's github_repositories block in osinfra-io/pt-logos@main and returns matches by exact repository name (case-sensitive, matching GitHub). Requires GITHUB_TOKEN.",
+		Description: "Find which team(s) own a github repository. Walks every team's github_repositories block in osinfra-io/pt-logos@main and returns matches by exact repository name (case-sensitive, matching GitHub). Requires NOMOS_GITHUB_TOKEN.",
 		Annotations: &mcp.ToolAnnotations{
 			Title:        "Find repository owner",
 			ReadOnlyHint: true,

--- a/internal/tools/get_team.go
+++ b/internal/tools/get_team.go
@@ -26,11 +26,11 @@ type GetTeamOutput struct {
 	DocsPages []string       `json:"docs_pages,omitempty"`
 }
 
-// GetTeam registers the get_team tool. Requires GITHUB_TOKEN.
+// GetTeam registers the get_team tool. Requires NOMOS_GITHUB_TOKEN.
 func GetTeam(s *mcp.Server, v *spec.Validator, c gh.Client) {
 	mcp.AddTool(s, &mcp.Tool{
 		Name:        "get_team",
-		Description: "Fetch one team's parsed spec from teams/<team_key>.tfvars in osinfra-io/pt-logos@main. Returns {spec: <object>} in the same JSON shape validate_team_spec and render_team_tfvars accept. Requires GITHUB_TOKEN.",
+		Description: "Fetch one team's parsed spec from teams/<team_key>.tfvars in osinfra-io/pt-logos@main. Returns {spec: <object>} in the same JSON shape validate_team_spec and render_team_tfvars accept. Requires NOMOS_GITHUB_TOKEN.",
 		Annotations: &mcp.ToolAnnotations{
 			Title:        "Get team",
 			ReadOnlyHint: true,

--- a/internal/tools/list_teams.go
+++ b/internal/tools/list_teams.go
@@ -37,11 +37,11 @@ type ListTeamsOutput struct {
 	Teams []TeamSummary `json:"teams"`
 }
 
-// ListTeams registers the list_teams tool. Requires GITHUB_TOKEN.
+// ListTeams registers the list_teams tool. Requires NOMOS_GITHUB_TOKEN.
 func ListTeams(s *mcp.Server, v *spec.Validator, c gh.Client) {
 	mcp.AddTool(s, &mcp.Tool{
 		Name:        "list_teams",
-		Description: "List every team defined under teams/ in osinfra-io/pt-logos@main, with one summary row per team. Requires GITHUB_TOKEN.",
+		Description: "List every team defined under teams/ in osinfra-io/pt-logos@main, with one summary row per team. Requires NOMOS_GITHUB_TOKEN.",
 		Annotations: &mcp.ToolAnnotations{
 			Title:        "List teams",
 			ReadOnlyHint: true,

--- a/internal/tools/lookup_user.go
+++ b/internal/tools/lookup_user.go
@@ -55,11 +55,11 @@ type LookupUserOutput struct {
 	Matches []LookupUserMatch `json:"matches"`
 }
 
-// LookupUser registers the lookup_user tool. Requires GITHUB_TOKEN.
+// LookupUser registers the lookup_user tool. Requires NOMOS_GITHUB_TOKEN.
 func LookupUser(s *mcp.Server, v *spec.Validator, c gh.Client) {
 	mcp.AddTool(s, &mcp.Tool{
 		Name:        "lookup_user",
-		Description: "Find every team and role where a user appears across all teams in osinfra-io/pt-logos@main. Provide exactly one of github_username (matched case-insensitively against GitHub roles) or email (matched case-insensitively against Datadog and Google group roles). Returns {matches: []} (possibly empty) — empty is success, not an error. Requires GITHUB_TOKEN.",
+		Description: "Find every team and role where a user appears across all teams in osinfra-io/pt-logos@main. Provide exactly one of github_username (matched case-insensitively against GitHub roles) or email (matched case-insensitively against Datadog and Google group roles). Returns {matches: []} (possibly empty) — empty is success, not an error. Requires NOMOS_GITHUB_TOKEN.",
 		Annotations: &mcp.ToolAnnotations{
 			Title:        "Look up user",
 			ReadOnlyHint: true,

--- a/internal/tools/next_available_cidrs.go
+++ b/internal/tools/next_available_cidrs.go
@@ -26,11 +26,11 @@ type NextAvailableCidrsOutput struct {
 }
 
 // NextAvailableCidrs registers the next_available_cidrs tool.
-// Requires GITHUB_TOKEN.
+// Requires NOMOS_GITHUB_TOKEN.
 func NextAvailableCidrs(s *mcp.Server, v *spec.Validator, c gh.Client) {
 	mcp.AddTool(s, &mcp.Tool{
 		Name:        "next_available_cidrs",
-		Description: "Compute the next N unallocated GKE subnet CIDR slots by scanning all team specs in osinfra-io/pt-logos@main. Returns deterministic CIDR allocations for ip_cidr_range, pod_ip_cidr_range, services_ip_cidr_range, and master_ipv4_cidr_block. Requires GITHUB_TOKEN.",
+		Description: "Compute the next N unallocated GKE subnet CIDR slots by scanning all team specs in osinfra-io/pt-logos@main. Returns deterministic CIDR allocations for ip_cidr_range, pod_ip_cidr_range, services_ip_cidr_range, and master_ipv4_cidr_block. Requires NOMOS_GITHUB_TOKEN.",
 		Annotations: &mcp.ToolAnnotations{
 			Title:        "Next available CIDRs",
 			ReadOnlyHint: true,

--- a/internal/tools/open_team_docs_pr.go
+++ b/internal/tools/open_team_docs_pr.go
@@ -51,7 +51,7 @@ const sidebarsPath = "sidebars.js"
 func OpenTeamDocsPR(s *mcp.Server, v *spec.Validator, c gh.Client) {
 	mcp.AddTool(s, &mcp.Tool{
 		Name:        "open_team_docs_pr",
-		Description: "Validate, render index.md, patch sidebars.js, and open-or-update a PR on osinfra-io/pt-ekklesia-docs for the given team spec. Idempotent. display_name_comment must be non-empty in the spec (it becomes the page description and lede paragraph). Requires GITHUB_TOKEN with write access to pt-ekklesia-docs.",
+		Description: "Validate, render index.md, patch sidebars.js, and open-or-update a PR on osinfra-io/pt-ekklesia-docs for the given team spec. Idempotent. display_name_comment must be non-empty in the spec (it becomes the page description and lede paragraph). Requires NOMOS_GITHUB_TOKEN with write access to pt-ekklesia-docs.",
 		Annotations: &mcp.ToolAnnotations{
 			Title:        "Open team docs PR",
 			ReadOnlyHint: false,

--- a/internal/tools/open_team_helpers_pr.go
+++ b/internal/tools/open_team_helpers_pr.go
@@ -43,12 +43,12 @@ type TeamHelpersPRResult struct {
 }
 
 // OpenTeamHelpersPR registers the open_team_helpers_pr tool.
-// Requires GITHUB_TOKEN with write access to osinfra-io/pt-corpus and
+// Requires NOMOS_GITHUB_TOKEN with write access to osinfra-io/pt-corpus and
 // osinfra-io/pt-pneuma.
 func OpenTeamHelpersPR(s *mcp.Server, c gh.Client) {
 	mcp.AddTool(s, &mcp.Tool{
 		Name:        "open_team_helpers_pr",
-		Description: "Render helpers.tofu for both osinfra-io/pt-corpus and osinfra-io/pt-pneuma and open-or-update a PR in each with '<team_key>-main-production' inserted into logos_workspaces. Idempotent: returns action=noop per repo when the rendered content already matches the branch (with an open PR) or main. Requires GITHUB_TOKEN.",
+		Description: "Render helpers.tofu for both osinfra-io/pt-corpus and osinfra-io/pt-pneuma and open-or-update a PR in each with '<team_key>-main-production' inserted into logos_workspaces. Idempotent: returns action=noop per repo when the rendered content already matches the branch (with an open PR) or main. Requires NOMOS_GITHUB_TOKEN.",
 		Annotations: &mcp.ToolAnnotations{
 			Title:        "Open team helpers PR",
 			ReadOnlyHint: false,

--- a/internal/tools/open_team_pr.go
+++ b/internal/tools/open_team_pr.go
@@ -53,7 +53,7 @@ const coAuthoredTrailer = "\n\nCo-authored-by: Copilot <223556219+Copilot@users.
 func OpenTeamPR(s *mcp.Server, v *spec.Validator, c gh.Client) {
 	mcp.AddTool(s, &mcp.Tool{
 		Name:        "open_team_pr",
-		Description: "Validate, render, and open-or-update a PR on osinfra-io/pt-logos for the given team spec. Idempotent: returns action=noop when the rendered tfvars already match the branch (with an open PR) or main. Requires GITHUB_TOKEN to be configured at server startup.",
+		Description: "Validate, render, and open-or-update a PR on osinfra-io/pt-logos for the given team spec. Idempotent: returns action=noop when the rendered tfvars already match the branch (with an open PR) or main. Requires NOMOS_GITHUB_TOKEN to be configured at server startup.",
 		Annotations: &mcp.ToolAnnotations{
 			Title:        "Open team PR",
 			ReadOnlyHint: false,
@@ -63,7 +63,7 @@ func OpenTeamPR(s *mcp.Server, v *spec.Validator, c gh.Client) {
 		if c == nil {
 			return errResult(opError{
 				Code:    "not_configured",
-				Message: "open_team_pr requires GITHUB_TOKEN; see README Configuration",
+				Message: "open_team_pr requires NOMOS_GITHUB_TOKEN; see README Configuration",
 			}), nil, nil
 		}
 		specMap, err := coerceSpec(in.Spec)

--- a/internal/tools/read_errors.go
+++ b/internal/tools/read_errors.go
@@ -3,7 +3,7 @@
 // notConfigured and notFound are the two opError shapes the read tools
 // share. They live next to the read tools rather than open_team_pr's
 // errResult/apiError/opError because their messages reference read-tool
-// behavior (GITHUB_TOKEN required, "team X not found"), not write-tool
+// behavior (NOMOS_GITHUB_TOKEN required, "team X not found"), not write-tool
 // behavior.
 package tools
 
@@ -11,11 +11,11 @@ import "github.com/modelcontextprotocol/go-sdk/mcp"
 
 // notConfigured returns the standard not_configured opError result for
 // a read tool that was constructed with a nil github client (no
-// GITHUB_TOKEN at server start).
+// NOMOS_GITHUB_TOKEN at server start).
 func notConfigured(toolName string) *mcp.CallToolResult {
 	return errResult(opError{
 		Code:    "not_configured",
-		Message: toolName + " requires GITHUB_TOKEN; see README Configuration",
+		Message: toolName + " requires NOMOS_GITHUB_TOKEN; see README Configuration",
 	})
 }
 

--- a/internal/tools/render_team_helpers.go
+++ b/internal/tools/render_team_helpers.go
@@ -34,12 +34,12 @@ type RenderTeamHelpersResult struct {
 }
 
 // RenderTeamHelpers registers the render_team_helpers tool.
-// Requires GITHUB_TOKEN with read access to osinfra-io/pt-corpus and
+// Requires NOMOS_GITHUB_TOKEN with read access to osinfra-io/pt-corpus and
 // osinfra-io/pt-pneuma.
 func RenderTeamHelpers(s *mcp.Server, c gh.Client) {
 	mcp.AddTool(s, &mcp.Tool{
 		Name:        "render_team_helpers",
-		Description: "Fetch helpers.tofu from both osinfra-io/pt-corpus and osinfra-io/pt-pneuma@main and return canonical bytes with '<team_key>-main-production' inserted into logos_workspaces in each. Idempotent: returns the input bytes unchanged when the workspace is already present. Requires GITHUB_TOKEN.",
+		Description: "Fetch helpers.tofu from both osinfra-io/pt-corpus and osinfra-io/pt-pneuma@main and return canonical bytes with '<team_key>-main-production' inserted into logos_workspaces in each. Idempotent: returns the input bytes unchanged when the workspace is already present. Requires NOMOS_GITHUB_TOKEN.",
 		Annotations: &mcp.ToolAnnotations{
 			Title:        "Render team helpers",
 			ReadOnlyHint: true,


### PR DESCRIPTION
## Summary

Renames the `GITHUB_TOKEN` environment variable to `NOMOS_GITHUB_TOKEN` throughout the MCP server.

## Problem

Setting `GITHUB_TOKEN` in the shell to supply a fine-grained PAT for the MCP server conflicts with the Copilot CLI, which reads the same variable for its own GitHub authentication — causing auth failures.

## Change

- `cmd/pt-techne-mcp-server/main.go` — reads `NOMOS_GITHUB_TOKEN` instead of `GITHUB_TOKEN`
- All tool descriptions, comments, and error messages updated to match
- `docs/configuration.md`, `README.md`, `Dockerfile`, `.github/copilot-instructions.md` updated

The `GITHUB_TOKEN` references in `.github/workflows/` are the GitHub Actions built-in token used by the release workflow itself — those are intentionally unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated setup and configuration guidance to use `NOMOS_GITHUB_TOKEN` instead of `GITHUB_TOKEN` across README, config docs, Docker guidance, and tool descriptions.
  * Clarified the startup error message when the token is missing.

* **Bug Fixes**
  * GitHub-backed features now read the new environment variable consistently at startup, helping prevent token-related configuration issues.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->