### PR TITLE
Remove optional service account field from namespace schema

### DIFF
--- a/internal/spec/schema_embed.json
+++ b/internal/spec/schema_embed.json
@@ -616,10 +616,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "google_service_account": {
-          "description": "Email of the GCP service account to bind to the Kubernetes service account in this namespace via Workload Identity. When omitted, the namespace is created but no Workload Identity binding is provisioned.",
-          "type": "string"
-        },
         "istio_injection": {
           "description": "Whether to enable Istio sidecar injection in this namespace. Defaults to disabled.",
           "type": "string",


### PR DESCRIPTION
## What

Removes the optional `google_service_account` property from the `gkeNamespaceEntry` definition in the team spec schema.

## Why

As part of the team-based namespace provisioning model, pneuma now **always** generates a Workload Identity service account for every namespace it creates. The per-namespace `google_service_account` binding field is therefore obsolete — a namespace no longer needs the caller to supply an SA email to opt into a Workload Identity binding.

The runtime workload identity binding (e.g. for a workload that calls GCP APIs) is requested separately through the Nomos agent when a team is ready, so it does not belong in the static namespace spec.

Part of the cross-repo team-based namespace provisioning change (see pt-logos namespace schema cleanup and pt-pneuma provisioning refactor).

## Validation

- `go test ./...` passes
- `schemadoc` pre-commit hook passes (no doc changes; the field was not surfaced in docs/schema.md)